### PR TITLE
Flesh out API

### DIFF
--- a/src/MatrixBandwidth.jl
+++ b/src/MatrixBandwidth.jl
@@ -14,9 +14,24 @@ the latest development version of this package.
 """
 module MatrixBandwidth
 
-# TODO: Exports go here
+export
+    # The main function
+    minimize_bandwidth,
 
-include("minimize_bandwidth.jl")
+    # Exact solvers
+    MBID,
+    MBPS,
+
+    # Heuristic solvers
+    CuthillMcKee,
+    ReverseCuthillMcKee,
+
+    # Metaheuristic solvers
+    SimulatedAnnealing,
+    GeneticAlgorithm,
+    GRASP
+
+include("types.jl")
 
 include("exact/mbid.jl")
 include("exact/mbps.jl")
@@ -27,5 +42,7 @@ include("heuristic/reverse_cuthill_mckee.jl")
 include("metaheuristic/simulated_annealing.jl")
 include("metaheuristic/genetic_algorithm.jl")
 include("metaheuristic/grasp.jl")
+
+include("minimize_bandwidth.jl")
 
 end

--- a/src/exact/mbid.jl
+++ b/src/exact/mbid.jl
@@ -4,4 +4,13 @@
 # http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
 # distributed except according to those terms.
 
-# TODO: Write here
+"""
+    MBID <: ExactSolver <: AbstractSolver
+
+TODO: Write here
+"""
+struct MBID <: ExactSolver end
+
+Base.summary(::MBID) = "Matrix bandwidth by iterative deepening"
+
+# TODO: Define `minimize_bandwidth` method for `MBID`

--- a/src/exact/mbps.jl
+++ b/src/exact/mbps.jl
@@ -4,4 +4,13 @@
 # http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
 # distributed except according to those terms.
 
-# TODO: Write here
+"""
+    MBPS <: ExactSolver <: AbstractSolver
+
+TODO: Write here
+"""
+struct MBPS <: ExactSolver end
+
+Base.summary(::MBPS) = "Matrix bandwidth by perimeter search"
+
+# TODO: Define `minimize_bandwidth` method for `MBPS`

--- a/src/heuristic/cuthill_mckee.jl
+++ b/src/heuristic/cuthill_mckee.jl
@@ -4,4 +4,13 @@
 # http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
 # distributed except according to those terms.
 
-# TODO: Write here
+"""
+    CuthillMcKee <: HeuristicSolver <: AbstractSolver
+
+TODO: Write here
+"""
+struct CuthillMcKee <: HeuristicSolver end
+
+Base.summary(::CuthillMcKee) = "Cuthill–McKee algorithm"
+
+# TODO: Define `minimize_bandwidth` method for `CuthillMcKee`

--- a/src/heuristic/reverse_cuthill_mckee.jl
+++ b/src/heuristic/reverse_cuthill_mckee.jl
@@ -4,4 +4,13 @@
 # http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
 # distributed except according to those terms.
 
-# TODO: Write here
+"""
+    ReverseCuthillMcKee <: HeuristicSolver <: AbstractSolver
+
+TODO: Write here
+"""
+struct ReverseCuthillMcKee <: HeuristicSolver end
+
+Base.summary(::ReverseCuthillMcKee) = "Reverse Cuthill–McKee algorithm"
+
+# TODO: Define `minimize_bandwidth` method for `ReverseCuthillMcKee`

--- a/src/metaheuristic/genetic_algorithm.jl
+++ b/src/metaheuristic/genetic_algorithm.jl
@@ -4,4 +4,13 @@
 # http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
 # distributed except according to those terms.
 
-# TODO: Write here
+"""
+    GeneticAlgorithm <: MetaheuristicSolver <: AbstractSolver
+
+TODO: Write here
+"""
+struct GeneticAlgorithm <: MetaheuristicSolver end
+
+Base.summary(::GeneticAlgorithm) = "Genetic algorithm"
+
+# TODO: Define `minimize_bandwidth` method for `GeneticAlgorithm`

--- a/src/metaheuristic/grasp.jl
+++ b/src/metaheuristic/grasp.jl
@@ -4,4 +4,13 @@
 # http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
 # distributed except according to those terms.
 
-# TODO: Write here
+"""
+    GRASP <: MetaheuristicSolver <: AbstractSolver
+
+TODO: Write here
+"""
+struct GRASP <: MetaheuristicSolver end
+
+Base.summary(::GRASP) = "Greedy randomized adaptive search procedure"
+
+# TODO: Define `minimize_bandwidth` method for `GRASP`

--- a/src/metaheuristic/simulated_annealing.jl
+++ b/src/metaheuristic/simulated_annealing.jl
@@ -4,4 +4,13 @@
 # http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
 # distributed except according to those terms.
 
-# TODO: Write here
+"""
+    SimulatedAnnealing <: MetaheuristicSolver <: AbstractSolver
+
+TODO: Write here
+"""
+struct SimulatedAnnealing <: MetaheuristicSolver end
+
+Base.summary(::SimulatedAnnealing) = "Simulated annealing"
+
+# TODO: Define `minimize_bandwidth` method for `SimulatedAnnealing`

--- a/src/minimize_bandwidth.jl
+++ b/src/minimize_bandwidth.jl
@@ -4,4 +4,17 @@
 # http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
 # distributed except according to those terms.
 
-# TODO: Write here
+const DEFAULT_SOLVER = ReverseCuthillMcKee()
+
+"""
+    minimize_bandwidth(A::AbstractMatrix) -> BandwidthResult
+    minimize_bandwidth(A::AbstractMatrix, solver::AbstractSolver) -> BandwidthResult
+
+TODO: Write here
+"""
+minimize_bandwidth(A::AbstractMatrix{<:Number}) = minimize_bandwidth(A, DEFAULT_SOLVER)
+
+function minimize_bandwidth(A::AbstractMatrix{<:Number}, solver::AbstractSolver)
+    A_bool::AbstractMatrix{Bool} = (!iszero).(A)
+    return minimize_bandwidth(A_bool, solver)
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,0 +1,65 @@
+# Copyright 2025 Luis M. B. Varona
+#
+# Licensed under the MIT license <LICENSE or
+# http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
+# distributed except according to those terms.
+
+"""
+    AbstractSolver
+
+TODO: Write here
+"""
+abstract type AbstractSolver end
+
+"""
+    ExactSolver <: AbstractSolver
+
+TODO: Write here
+"""
+abstract type ExactSolver <: AbstractSolver end
+
+"""
+    HeuristicSolver <: AbstractSolver
+
+TODO: Write here
+"""
+abstract type HeuristicSolver <: AbstractSolver end
+
+"""
+    MetaheuristicSolver <: AbstractSolver
+
+TODO: Write here
+"""
+abstract type MetaheuristicSolver <: AbstractSolver end
+
+"""
+    approach(solver::AbstractSolver) -> Symbol
+
+TODO: Write here
+"""
+approach(::ExactSolver) = :exact
+approach(::HeuristicSolver) = :heuristic
+approach(::MetaheuristicSolver) = :metaheuristic
+
+"""
+    BandwidthResult
+
+TODO: Write here
+"""
+struct BandwidthResult{M<:AbstractMatrix{<:Number},S<:AbstractSolver}
+    matrix::M
+    bandwidth::Int
+    perm::Vector{Int}
+    solver::S
+    approach::Symbol # :exact, :heuristic, or :metaheuristic
+
+    function BandwidthResult(
+        matrix::M, bandwidth::Int, perm::Vector{Int}, solver::S
+    ) where {M<:AbstractMatrix{<:Number},S<:AbstractSolver}
+        return new{M,S}(matrix, bandwidth, perm, solver, approach(solver))
+    end
+end
+
+Base.summary(res::BandwidthResult) = summary(res.solver)
+
+# TODO: Override `Base.show(io::IO, res::BandwidthResult)`


### PR DESCRIPTION
Added a `types.jl` file to contain all the abstract types and the output struct (`BandwidthResult`). Defined all the solver structs in their respective files and exported them from the main `MatrixBandwidth` module.

The actual `minimize_bandwidth` logic for each solver struct remains to be implemented, as well as comprehensive documentation and tests.