### PR TITLE
Add solver params; update main function API

### DIFF
--- a/src/exact/mbid.jl
+++ b/src/exact/mbid.jl
@@ -13,4 +13,6 @@ struct MBID <: ExactSolver end
 
 Base.summary(::MBID) = "Matrix bandwidth by iterative deepening"
 
-# TODO: Define `minimize_bandwidth` method for `MBID`
+function _minimize_bandwidth_safe(A::AbstractMatrix{<:Bool}, ::MBID)
+    # TODO: Implement
+end

--- a/src/exact/mbps.jl
+++ b/src/exact/mbps.jl
@@ -9,8 +9,12 @@
 
 TODO: Write here
 """
-struct MBPS <: ExactSolver end
+struct MBPS <: ExactSolver
+    depth::Int
+end
 
 Base.summary(::MBPS) = "Matrix bandwidth by perimeter search"
 
-# TODO: Define `minimize_bandwidth` method for `MBPS`
+function _minimize_bandwidth_safe(A::AbstractMatrix{<:Bool}, solver::MBPS)
+    # TODO: Implement
+end

--- a/src/heuristic/cuthill_mckee.jl
+++ b/src/heuristic/cuthill_mckee.jl
@@ -13,4 +13,6 @@ struct CuthillMcKee <: HeuristicSolver end
 
 Base.summary(::CuthillMcKee) = "Cuthill–McKee algorithm"
 
-# TODO: Define `minimize_bandwidth` method for `CuthillMcKee`
+function _minimize_bandwidth_safe(A::AbstractMatrix{<:Bool}, ::CuthillMcKee)
+    # TODO: Implement
+end

--- a/src/heuristic/reverse_cuthill_mckee.jl
+++ b/src/heuristic/reverse_cuthill_mckee.jl
@@ -13,4 +13,6 @@ struct ReverseCuthillMcKee <: HeuristicSolver end
 
 Base.summary(::ReverseCuthillMcKee) = "Reverse Cuthill–McKee algorithm"
 
-# TODO: Define `minimize_bandwidth` method for `ReverseCuthillMcKee`
+function _minimize_bandwidth_safe(A::AbstractMatrix{<:Bool}, ::ReverseCuthillMcKee)
+    # TODO: Implement
+end

--- a/src/metaheuristic/genetic_algorithm.jl
+++ b/src/metaheuristic/genetic_algorithm.jl
@@ -9,8 +9,12 @@
 
 TODO: Write here
 """
-struct GeneticAlgorithm <: MetaheuristicSolver end
+struct GeneticAlgorithm <: MetaheuristicSolver
+    # TODO: Define fields and constructor (for default values)
+end
 
 Base.summary(::GeneticAlgorithm) = "Genetic algorithm"
 
-# TODO: Define `minimize_bandwidth` method for `GeneticAlgorithm`
+function _minimize_bandwidth_safe(A::AbstractMatrix{<:Bool}, solver::GeneticAlgorithm)
+    # TODO: Implement
+end

--- a/src/metaheuristic/grasp.jl
+++ b/src/metaheuristic/grasp.jl
@@ -9,8 +9,12 @@
 
 TODO: Write here
 """
-struct GRASP <: MetaheuristicSolver end
+struct GRASP <: MetaheuristicSolver
+    # TODO: Define fields and constructor (for default values)
+end
 
 Base.summary(::GRASP) = "Greedy randomized adaptive search procedure"
 
-# TODO: Define `minimize_bandwidth` method for `GRASP`
+function _minimize_bandwidth_safe(A::AbstractMatrix{<:Bool}, Solver::GRASP)
+    # TODO: Implement
+end

--- a/src/metaheuristic/simulated_annealing.jl
+++ b/src/metaheuristic/simulated_annealing.jl
@@ -9,8 +9,18 @@
 
 TODO: Write here
 """
-struct SimulatedAnnealing <: MetaheuristicSolver end
+struct SimulatedAnnealing <: MetaheuristicSolver
+    initial_temp::Float64
+    cooling_rate::Float64
+    max_iterations::Int
+    max_no_improve::Int
+    seed::Union{Nothing,Int}
+
+    # TODO: Make constructor with default values
+end
 
 Base.summary(::SimulatedAnnealing) = "Simulated annealing"
 
-# TODO: Define `minimize_bandwidth` method for `SimulatedAnnealing`
+function _minimize_bandwidth_safe(A::AbstractMatrix{<:Bool}, solver::SimulatedAnnealing)
+    # TODO: Implement
+end

--- a/src/minimize_bandwidth.jl
+++ b/src/minimize_bandwidth.jl
@@ -7,14 +7,24 @@
 const DEFAULT_SOLVER = ReverseCuthillMcKee()
 
 """
-    minimize_bandwidth(A::AbstractMatrix) -> BandwidthResult
-    minimize_bandwidth(A::AbstractMatrix, solver::AbstractSolver) -> BandwidthResult
+    minimize_bandwidth(A, solver=ReverseCuthillMcKee()) -> BandwidthResult
 
 TODO: Write here
 """
-minimize_bandwidth(A::AbstractMatrix{<:Number}) = minimize_bandwidth(A, DEFAULT_SOLVER)
+function minimize_bandwidth(
+    A::AbstractMatrix{<:Bool}, solver::AbstractSolver=DEFAULT_SOLVER
+)
+    if !allequal(size(A))
+        throw(ArgumentError("Matrix bandwidth is not defined for non-square matrices"))
+    end
 
-function minimize_bandwidth(A::AbstractMatrix{<:Number}, solver::AbstractSolver)
+    A_copy = copy(A)
+    return _minimize_bandwidth_safe(A_copy, solver)
+end
+
+function minimize_bandwidth(
+    A::AbstractMatrix{<:Number}, solver::AbstractSolver=DEFAULT_SOLVER
+)
     A_bool::AbstractMatrix{Bool} = (!iszero).(A)
     return minimize_bandwidth(A_bool, solver)
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -33,7 +33,7 @@ TODO: Write here
 abstract type MetaheuristicSolver <: AbstractSolver end
 
 """
-    approach(solver::AbstractSolver) -> Symbol
+    approach(::AbstractSolver) -> Symbol
 
 TODO: Write here
 """


### PR DESCRIPTION
Added fields to the solver structs where needed (or, at least, indicated with a `TODO` that fields should be added instead of leaving the struct trivial). Updated the main function API to assert out of the gate that the matrix is square and to copy to avoid shared mutability. Also made the `DEFAULT_SOLVER` behavior more elegant with a default arg. Finally, corrected the (unfinished) approach docstring in `types.jl`.