### PR TITLE
Fix capitalization of docs URLs in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
   <tr>
     <td>Documentation</td>
     <td>
-      <a href="https://Luis-Varona.github.io/MatrixBandwidth.jl/stable/"><img src="https://img.shields.io/badge/docs-stable-darkgreen.svg" alt="Documentation of latest stable version"></a>
-      <a href="https://Luis-Varona.github.io/MatrixBandwidth.jl/dev/"><img src="https://img.shields.io/badge/docs-dev-rebeccapurple.svg" alt="Documentation of dev version"></a>
+      <a href="https://luis-varona.github.io/MatrixBandwidth.jl/stable/"><img src="https://img.shields.io/badge/docs-stable-darkgreen.svg" alt="Documentation of latest stable version"></a>
+      <a href="https://luis-varona.github.io/MatrixBandwidth.jl/dev/"><img src="https://img.shields.io/badge/docs-dev-rebeccapurple.svg" alt="Documentation of dev version"></a>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
It doesn't change the validity of the hyperlinks, but I lowercased my user name in the docs URLs for the sake of idiomatic code.