### PR TITLE
Finish documentation for `Heuristic` module

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,9 @@ version = "0.1.0-dev"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 DataStructures = ">=0.18.15, <1.0"
+Random = "1.10"
 julia = "1.10"

--- a/README.md
+++ b/README.md
@@ -43,16 +43,21 @@
 
 ## Algorithms
 
-- Exact
+The following algorithms are currently supported:
+
+- **Exact**
   - Minimum bandwidth by iterative deepening (MB-ID)
   - Minimum bandwidth by perimeter search (MB-PS)
-- Heuristic
+- **Heuristic**
   - Cuthill&ndash;McKee algorithm
   - Reverse Cuthill&ndash;McKee algorithm
-- Metaheuristic
+- **Metaheuristic**
   - Simulated annealing
   - Genetic algorithm
   - Greedy randomized adaptive search procedure (GRASP)
+
+(As we remain in the early stages of development, some of these may not yet be fully
+implememnted and/or tested.)
 
 ## Installation
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,3 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 MatrixBandwidth = "075aa41b-24fd-4573-b25f-92cae432c0f8"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,9 @@
+# Copyright 2025 Luis M. B. Varona and Nathaniel Johnston
+#
+# Licensed under the MIT license <LICENSE or
+# http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
+# distributed except according to those terms.
+
 using MatrixBandwidth
 using Documenter
 using DocumenterCitations
@@ -15,10 +21,14 @@ makedocs(;
     format=Documenter.HTML(;
         canonical="https://Luis-Varona.github.io/MatrixBandwidth.jl",
         edit_link="main",
-        assets=String[],
+        assets=["assets/styles.css"],
     ),
     plugins=[bib],
-    pages=["Home" => "index.md"],
+    pages=[
+        "Home" => "index.md",
+        "Public API" => "public_api.md",
+        "Private API" => "private_api.md",
+    ],
 )
 
 deploydocs(; repo="github.com/Luis-Varona/MatrixBandwidth.jl", devbranch="main")

--- a/docs/src/assets/styles.css
+++ b/docs/src/assets/styles.css
@@ -1,0 +1,40 @@
+html {
+  --table-border-color: white;
+  --table-row-shade: rgba(255, 255, 255, 0.1);
+}
+
+html.theme--documenter-light,
+html.theme--catppuccin-latte {
+  --table-border-color: black;
+  --table-row-shade: rgba(0, 0, 0, 0.1);
+}
+
+@media (prefers-color-scheme: light) {
+  html {
+    --table-border-color: black;
+    --table-row-shade: rgba(0, 0, 0, 0.1);
+  }
+}
+
+table {
+  width: auto;
+  border-collapse: collapse;
+}
+
+table tr:nth-child(even) {
+  background-color: var(--table-row-shade);
+}
+
+tr, th, td {
+  border: 1px solid var(--table-border-color);
+}
+
+table > tbody > tr > th:first-child,
+table > tbody > tr > td:first-child {
+  border-right: 1px solid var(--table-border-color) !important;
+}
+
+table > tbody > tr > th:last-child,
+table > tbody > tr > td:last-child {
+  border-left: 1px solid var(--table-border-color) !important;
+}

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,13 +2,92 @@
 CurrentModule = MatrixBandwidth
 ```
 
-# MatrixBandwidth
-
-Documentation for [MatrixBandwidth](https://github.com/Luis-Varona/MatrixBandwidth.jl).
-
-```@index
+```@raw html
+<table>
+  <tr>
+    <td>Metadata</td>
+    <td>
+      <img src="https://img.shields.io/badge/version-v0.1.0--dev-pink.svg" alt="Version">
+      <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-A31F34.svg" alt="License: MIT"></a>
+      <a href="https://github.com/JuliaDiff/BlueStyle"><img src="https://img.shields.io/badge/code%20style-blue-4495d1.svg" alt="Code Style: Blue"></a>
+    </td>
+  </tr>
+  <tr>
+    <td>Documentation</td>
+    <td>
+      <a href="https://luis-varona.github.io/MatrixBandwidth.jl/stable/"><img src="https://img.shields.io/badge/docs-stable-darkgreen.svg" alt="Documentation of latest stable version"></a>
+      <a href="https://luis-varona.github.io/MatrixBandwidth.jl/dev/"><img src="https://img.shields.io/badge/docs-dev-rebeccapurple.svg" alt="Documentation of dev version"></a>
+    </td>
+  </tr>
+  <tr>
+    <td>Continuous integration</td>
+    <td>
+      <a href="https://github.com/Luis-Varona/MatrixBandwidth.jl/actions?query=workflow%3ACI+branch%3Amain"><img src="https://github.com/Luis-Varona/MatrixBandwidth.jl/actions/workflows/CI.yml/badge.svg" alt="GitHub Workflow Status"></a>
+    </td>
+  </tr>
+  <tr>
+    <td>Code coverage</td>
+    <td>
+      <a href="https://codecov.io/gh/Luis-Varona/MatrixBandwidth.jl"><img src="https://img.shields.io/codecov/c/gh/Luis-Varona/MatrixBandwidth.jl.svg?label=codecov" alt="Test coverage from codecov"></a>
+    </td>
+    </tr>
+    <tr>
+      <td>Static analysis with</td>
+      <td>
+        <a href="https://github.com/JuliaTesting/Aqua.jl"><img src="https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg" alt="Aqua QA"></a>
+        <a href="https://github.com/aviatesk/JET.jl"><img src="https://img.shields.io/badge/%E2%9C%88%20tested%20with-JET.jl%EF%B8%8F-9cf.svg" alt="JET static analysis"></a>
+      </td>
+    </tr>
+</table>
 ```
 
-```@autodocs
-Modules = [MatrixBandwidth, MatrixBandwidth.Exact, MatrixBandwidth.Heuristic, MatrixBandwidth.Metaheuristic]
+## Overview
+
+*MatrixBandwidth.jl* offers several exact, heuristic, and metaheuristic algorithms for matrix bandwidth minimization.
+
+## Algorithms
+
+The following algorithms are currently supported:
+
+- **Exact**
+  - Minimum bandwidth by iterative deepening (MB-ID)
+  - Minimum bandwidth by perimeter search (MB-PS)
+- **Heuristic**
+  - Cuthill&ndash;McKee algorithm
+  - Reverse Cuthill&ndash;McKee algorithm
+- **Metaheuristic**
+  - Simulated annealing
+  - Genetic algorithm
+  - Greedy randomized adaptive search procedure (GRASP)
+
+(As we remain in the early stages of development, some of these may not yet be fully
+implememnted and/or tested.)
+
+## Installation
+
+The only prerequisite is a working Julia installation (v1.10 or later). First, enter Pkg mode by typing `]` in the Julia REPL, then run the following command:
+
+```julia-repl
+pkg> add https://github.com/Luis-Varona/MatrixBandwidth.jl
+```
+
+When *MatrixBandwidth.jl* is finally added to the official Julia registry, you will be able to install it more easily with:
+
+```julia-repl
+pkg> add MatrixBandwidth
+```
+
+## Citing
+
+I encourage you to cite this work if you have found any of the algorithms herein useful for your research. Starring the *MatrixBandwidth.jl* repository on GitHub is also appreciated.
+
+The latest citation information may be found in the [CITATION.bib](https://raw.githubusercontent.com/Luis-Varona/MatrixBandwidth.jl/main/CITATION.bib) file within the repository.
+
+## Project status
+
+I aim to release the first stable version of *MatrixBandwidth.jl* in mid-June 2025. The current version is a work-in-progress, with much of the API still under development.
+
+## Index
+
+```@index
 ```

--- a/docs/src/private_api.md
+++ b/docs/src/private_api.md
@@ -1,0 +1,17 @@
+```@meta
+CurrentModule = MatrixBandwidth
+```
+
+# MatrixBandwidth.jl – Private API
+
+Documentation for [MatrixBandwidth](https://github.com/Luis-Varona/MatrixBandwidth.jl)'s private API.
+
+!!! note
+    The following documentation covers only the private API of the package. For public details, see the [public API documentation](public_api.md).
+
+```@autodocs
+Modules = [MatrixBandwidth, MatrixBandwidth.Exact, MatrixBandwidth.Heuristic, MatrixBandwidth.Metaheuristic]
+Public = false
+```
+
+<!-- TODO: Insert a References section here once citations are added -->

--- a/docs/src/public_api.md
+++ b/docs/src/public_api.md
@@ -1,0 +1,21 @@
+```@meta
+CurrentModule = MatrixBandwidth
+```
+
+# MatrixBandwidth.jl – Public API
+
+Documentation for [MatrixBandwidth](https://github.com/Luis-Varona/MatrixBandwidth.jl)'s public API.
+
+!!! note
+    The following documentation covers only the public API of the package. For internal details, see the [private API documentation](private_api.md).
+
+```@autodocs
+Modules = [MatrixBandwidth, MatrixBandwidth.Exact, MatrixBandwidth.Heuristic, MatrixBandwidth.Metaheuristic]
+Private = false
+```
+
+## References
+
+```@bibliography
+Pages = [@__FILE__]
+```

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -1,8 +1,45 @@
+@inproceedings{CM69,
+  author = {Cuthill, Elizabeth and McKee, James},
+  booktitle = {Proceedings of the 24th National Conference of the ACM},
+  title = {Reducing the bandwidth of sparse symmetric matrices},
+  year = {1969},
+  pages = {157--72},
+  publisher = {Brandon Systems Press}
+}
+
+@phdthesis{Geo71,
+  author = "George, J. Alan",
+  school = "Department of Computer Science, Stanford University",
+  title = "Computer Implementation of the Finite Element Method",
+  year = {1971},
+  url = {https://apps.dtic.mil/sti/tr/pdf/AD0726171.pdf}
+}
+
 @misc{LLS+01,
-  title = "example/cuthill_mckee_ordering.cpp",
-  author = "Lumsdaine, Andrew and Lee, Lie-Quan and Siek, Jeremy G. and Gregor, Doug and McGrath, Kevin D.",
-  howpublished = "Boost reference documentation – v1.37.0",
-  year = 2001,
-  url = "https://www.boost.org/doc/libs/1_37_0/libs/graph/example/cuthill_mckee_ordering.cpp",
-  note = "Accessed: 2025-06-10",
+  author = {Lumsdaine, Andrew and Lee, Lie-Quan and Siek, Jeremy G. and Gregor, Doug and McGrath, Kevin D.},
+  howpublished = {Boost v1.37.0 documentation},
+  title = {example/cuthill_mckee_ordering.cpp},
+  year = {2001},
+  url = {https://www.boost.org/doc/libs/1_37_0/libs/graph/example/cuthill_mckee_ordering.cpp},
+  note = {Accessed: 2025-06-10}
+}
+
+@misc{Net25,
+  author = {{NetworkX Developers}},
+  howpublished = {NetworkX v3.5 documentation},
+  title = {Source code for networkx.utils.rcm},
+  year = {2025},
+  url = {https://networkx.org/documentation/stable/_modules/networkx/utils/rcm.html},
+  note = {Accessed: 2025-06-11}
+}
+
+@article{RS06,
+  author = {Reid, John K. and Scott, Jennifer A.},
+  journal = {SIAM Journal on Matrix Analysis and Applications},
+  number = {3},
+  title = {Reducing the Total Bandwidth of a Sparse Unsymmetric Matrix},
+  volume = {28},
+  pages = {805--21},
+  year = {2006},
+  url = {https://doi.org/10.1137/050629938}
 }

--- a/src/MatrixBandwidth.jl
+++ b/src/MatrixBandwidth.jl
@@ -9,10 +9,24 @@
 
 Exact, heuristic, and metaheuristic algorithms for matrix bandwidth minimization in Julia.
 
+The following algorithms are currently supported:
+- **Exact**
+    - [`MBID`](@ref): Minimum bandwidth by iterative deepening (MB-ID)
+    - [`MBPS`](@ref): Minimum bandwidth by perimeter search (MB-PS)
+- **Heuristic**
+    - [`CuthillMcKee`](@ref): Cuthill–McKee algorithm
+    - [`ReverseCuthillMcKee`](@ref): Reverse Cuthill–McKee algorithm
+- **Metaheuristic**
+    - [`SimulatedAnnealing`](@ref): Simulated annealing
+    - [`GeneticAlgorithm`](@ref): Genetic algorithm
+    - [`GRASP`](@ref): Greedy randomized adaptive search procedure (GRASP)
+
 [Full documentation](https://Luis-Varona.github.io/MatrixBandwidth.jl/dev/) is available for
 the latest development version of this package.
 """
 module MatrixBandwidth
+
+using Random
 
 include("utils.jl")
 include("types.jl")
@@ -24,7 +38,8 @@ include("metaheuristic/Metaheuristic.jl")
 
 using .Exact, .Heuristic, .Metaheuristic
 
-export minimize_bandwidth, BandwidthResult # The main function and output struct
+# The output struct, main minimization function, and raw bandwidth function
+export BandwidthResult, minimize_bandwidth, bandwidth_unpermuted
 export MBID, MBPS # Exact solvers
 export CuthillMcKee, ReverseCuthillMcKee # Heuristic solvers
 export SimulatedAnnealing, GeneticAlgorithm, GRASP # Metaheuristic solvers

--- a/src/exact/Exact.jl
+++ b/src/exact/Exact.jl
@@ -15,7 +15,7 @@ This submodule is part of the
 module Exact
 
 #! format: off
-import ..AbstractSolver, ..NotImplementedError, ..approach, .._sym_minimal_band_ordering
+import ..AbstractSolver, ..NotImplementedError, .._approach, .._bool_minimal_band_ordering
 #! format: on
 
 export MBID, MBPS

--- a/src/exact/mbid.jl
+++ b/src/exact/mbid.jl
@@ -13,6 +13,6 @@ struct MBID <: ExactSolver end
 
 Base.summary(::MBID) = "Matrix bandwidth by iterative deepening"
 
-function _sym_minimal_band_ordering(A::AbstractMatrix{Bool}, ::MBID)
+function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::MBID)
     # TODO: Implement
 end

--- a/src/exact/mbps.jl
+++ b/src/exact/mbps.jl
@@ -15,6 +15,6 @@ end
 
 Base.summary(::MBPS) = "Matrix bandwidth by perimeter search"
 
-function _sym_minimal_band_ordering(A::AbstractMatrix{Bool}, solver::MBPS)
+function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, solver::MBPS)
     # TODO: Implement
 end

--- a/src/exact/types.jl
+++ b/src/exact/types.jl
@@ -11,4 +11,4 @@ TODO: Write here
 """
 abstract type ExactSolver <: AbstractSolver end
 
-approach(::ExactSolver) = :exact
+_approach(::ExactSolver) = :exact

--- a/src/heuristic/Heuristic.jl
+++ b/src/heuristic/Heuristic.jl
@@ -9,13 +9,17 @@
 
 Heuristic solvers for matrix bandwidth minimization.
 
+The following heuristic algorithms are currently supported:
+- [`CuthillMcKee`](@ref): Cuthill–McKee algorithm
+- [`ReverseCuthillMcKee`](@ref): Reverse Cuthill–McKee algorithm
+
 This submodule is part of the
 [MatrixBandwidth.jl](https://github.com/Luis-Varona/MatrixBandwidth.jl) package.
 """
 module Heuristic
 
 #! format: off
-import ..AbstractSolver, ..NotImplementedError, ..approach, .._sym_minimal_band_ordering
+import ..AbstractSolver, ..NotImplementedError, .._approach, .._bool_minimal_band_ordering
 #! format: on
 
 using DataStructures: Queue, enqueue!, dequeue!

--- a/src/heuristic/reverse_cuthill_mckee.jl
+++ b/src/heuristic/reverse_cuthill_mckee.jl
@@ -7,7 +7,101 @@
 """
     ReverseCuthillMcKee <: HeuristicSolver <: AbstractSolver
 
-TODO: Write here
+The *reverse Cuthill–McKee algorithm* is a variant of the *Cuthill–McKee algorithm*—a
+heuristic method for minimizing the bandwidth of a symmetric matrix ``A``. Cuthill–McKee
+considers the graph ``G(A)`` whose adjacency matrix is ``A`` (ignoring self-loops) and
+performs a breadth-first search of each connected component of ``G(A)``, starting from a
+low-degree node then visiting its neighbors in order of increasing degree. Particularly
+effective when ``A`` is sparse, this heuristic typically produces an ordering which induces
+a matrix bandwidth either equal to or very close to the true minimum
+[CM69; pp. 157--58](@cite). The reverse Cuthill–McKee algorithm simply reverses the ordering
+produced by application of Cuthill–McKee; [Geo71; pp. 114--15](@cite) found that this tends
+to produce an even better ordering.
+
+We also extend the algorithm to work more generally when ``A`` is not symmetric by applying
+it to ``A + Aᵀ`` instead, as suggested in [RS06; p. 808](@cite). This approach still tends
+to produce a fairly good ordering, but it is not guaranteed to be as optimal as directly
+applying reverse Cuthill–McKee to a symmetric input.
+
+# Fields
+- `node_selector::Function`: a function that selects a node from some connected component of
+    the input matrix from which to start the breadth-first search. If no custom heuristic is
+    specified, this field defaults to [`pseudo_peripheral_node`](@ref), which picks a node
+    "farthest" from the others in the component (not necessarily the lowest-degree node).
+
+# Examples
+Reverse Cuthill–McKee finds an optimal ordering for an asymmetric ``45×45`` matrix with
+bandwidth ``4`` whose rows and columns have been shuffled:
+```jldoctest
+julia> using Random
+
+julia> Random.seed!(87);
+
+julia> (n, k) = (45, 4);
+
+julia> perm = randperm(n);
+
+julia> A = MatrixBandwidth.random_sparse_banded_matrix(n, k);
+
+julia> A_shuffled = A[perm, perm];
+
+julia> res = minimize_bandwidth(A_shuffled, ReverseCuthillMcKee());
+
+julia> iszero.(A_shuffled) == iszero.(A_shuffled') # Works even for asymmetric matrices
+false
+
+julia> bandwidth_unpermuted(A)
+4
+
+julia> bandwidth_unpermuted(A_shuffled)
+43
+
+julia> res.bandwidth # The true minimum bandwidth
+4
+```
+
+Reverse Cuthill–McKee finds a near-optimal ordering for an asymmetric ``250×250`` matrix
+with bandwidth ``14`` whose rows and columns have been shuffled:
+```jldoctest
+julia> using Random
+
+julia> Random.seed!(5747);
+
+julia> (n, k) = (250, 14);
+
+julia> perm = randperm(n);
+
+julia> A = MatrixBandwidth.random_sparse_banded_matrix(n, k);
+
+julia> A_shuffled = A[perm, perm];
+
+julia> res = minimize_bandwidth(A_shuffled, ReverseCuthillMcKee());
+
+julia> iszero.(A_shuffled) == iszero.(A_shuffled') # Works even for asymmetric matrices
+false
+
+julia> bandwidth_unpermuted(A)
+14
+
+julia> bandwidth_unpermuted(A_shuffled)
+245
+
+julia> res.bandwidth # Close to the true minimum
+17
+```
+
+# Notes
+See [`CuthillMcKee`](@ref) and the associated method of `_bool_minimal_band_ordering` for
+our implementation of the original Cuthill–McKee algorithm. (Indeed, the reverse
+Cuthill–McKee method of `_bool_minimal_band_ordering` is merely a wrapper around the
+Cuthill–McKee method.)
+
+Note also that the `node_selector` field must be of the form
+`(A::AbstractMatrix{Bool}) -> Integer` (i.e., it must take in an boolean matrix and return
+an integer). If this is not the case, an `ArgumentError` is thrown upon construction.
+
+See also the documentation for supertypes [`HeuristicSolver`](@ref) and
+[`AbstractSolver`](@ref).
 """
 struct ReverseCuthillMcKee <: HeuristicSolver
     node_selector::Function
@@ -20,6 +114,6 @@ end
 
 Base.summary(::ReverseCuthillMcKee) = "Reverse Cuthill–McKee algorithm"
 
-function _sym_minimal_band_ordering(A::AbstractMatrix{Bool}, solver::ReverseCuthillMcKee)
-    return reverse!(_sym_minimal_band_ordering(A, CuthillMcKee(solver.node_selector)))
+function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, solver::ReverseCuthillMcKee)
+    return reverse!(_bool_minimal_band_ordering(A, CuthillMcKee(solver.node_selector)))
 end

--- a/src/heuristic/types.jl
+++ b/src/heuristic/types.jl
@@ -11,4 +11,4 @@ TODO: Write here
 """
 abstract type HeuristicSolver <: AbstractSolver end
 
-approach(::HeuristicSolver) = :heuristic
+_approach(::HeuristicSolver) = :heuristic

--- a/src/heuristic/utils.jl
+++ b/src/heuristic/utils.jl
@@ -5,37 +5,27 @@
 # distributed except according to those terms.
 
 """
-    _assert_valid_node_selector(selector) -> Nothing
-
-TODO: Write here
-"""
-function _assert_valid_node_selector(selector::Function)
-    input = [false true; true false]
-
-    if !hasmethod(selector, Tuple{AbstractMatrix{Bool}})
-        throw(ArgumentError("`selector` must take an an AbstractMatrix{Bool} as input"))
-    end
-
-    try
-        output = selector(input)
-        if !(output isa Integer)
-            throw(ArgumentError("`selector` must return an Integer"))
-        end
-    catch
-        throw(
-            ArgumentError(
-                "`selector` throws an error when called on our test input (K₂'s adjacency)"
-            ),
-        )
-    end
-
-    return nothing
-end
-
-"""
     pseudo_peripheral_node(A::AbstractMatrix{Bool}) -> Int
 
-TODO: Write here
+Select a pseudo-peripheral node from the connected graph represented by `A`.
+
+This function acts as a node selector for the Cuthill–McKee and Reverse Cuthill–McKee
+algorithms, heuristically choosing the node "farthest" from the others in the graph. It is
+assumed that `A` is the adjacency matrix of some connected, undirected graph; otherwise,
+undefined behavior may arise.
+
+# Arguments
+- `A::AbstractMatrix{Bool}`: the adjacency matrix of some connected, undirected graph. In
+    practice, this semantically represents the connected component of some larger graph.
+
+# Returns
+- `Int`: the index of the pseudo-peripheral node selected from the graph.
+
+# Notes
+This function takes heavy inspiration from the implementation in [Net25](@cite), which
+accepts a graph object as input and leverages several pre-existing functions in the
+`networkx` library. We herein repurpose the logic to work directly on adjacency matrices,
+avoiding reallocation overhead and an unnecessary dependency on `Graphs.jl`.
 """
 function pseudo_peripheral_node(A::AbstractMatrix{Bool})
     n = size(A, 1)
@@ -90,4 +80,28 @@ function pseudo_peripheral_node(A::AbstractMatrix{Bool})
     end
 
     return v
+end
+
+# Validate that the `selector` function is a valid node selector
+function _assert_valid_node_selector(selector::Function)
+    input = [false true; true false]
+
+    if !hasmethod(selector, Tuple{AbstractMatrix{Bool}})
+        throw(ArgumentError("`selector` must take an an AbstractMatrix{Bool} as input"))
+    end
+
+    try
+        output = selector(input)
+        if !(output isa Integer)
+            throw(ArgumentError("`selector` must return an Integer"))
+        end
+    catch
+        throw(
+            ArgumentError(
+                "`selector` throws an error when called on our test input (K₂'s adjacency)"
+            ),
+        )
+    end
+
+    return nothing
 end

--- a/src/metaheuristic/Metaheuristic.jl
+++ b/src/metaheuristic/Metaheuristic.jl
@@ -15,7 +15,7 @@ This submodule is part of the
 module Metaheuristic
 
 #! format: off
-import ..AbstractSolver, ..NotImplementedError, ..approach, .._sym_minimal_band_ordering
+import ..AbstractSolver, ..NotImplementedError, .._approach, .._bool_minimal_band_ordering
 #! format: on
 
 export SimulatedAnnealing, GeneticAlgorithm, GRASP

--- a/src/metaheuristic/genetic_algorithm.jl
+++ b/src/metaheuristic/genetic_algorithm.jl
@@ -15,6 +15,6 @@ end
 
 Base.summary(::GeneticAlgorithm) = "Genetic algorithm"
 
-function _sym_minimal_band_ordering(A::AbstractMatrix{Bool}, solver::GeneticAlgorithm)
+function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, solver::GeneticAlgorithm)
     # TODO: Implement
 end

--- a/src/metaheuristic/grasp.jl
+++ b/src/metaheuristic/grasp.jl
@@ -15,6 +15,6 @@ end
 
 Base.summary(::GRASP) = "Greedy randomized adaptive search procedure"
 
-function _sym_minimal_band_ordering(A::AbstractMatrix{Bool}, Solver::GRASP)
+function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, Solver::GRASP)
     # TODO: Implement
 end

--- a/src/metaheuristic/simulated_annealing.jl
+++ b/src/metaheuristic/simulated_annealing.jl
@@ -21,6 +21,6 @@ end
 
 Base.summary(::SimulatedAnnealing) = "Simulated annealing"
 
-function _sym_minimal_band_ordering(A::AbstractMatrix{Bool}, solver::SimulatedAnnealing)
+function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, solver::SimulatedAnnealing)
     # TODO: Implement
 end

--- a/src/metaheuristic/types.jl
+++ b/src/metaheuristic/types.jl
@@ -11,4 +11,4 @@ TODO: Write here
 """
 abstract type MetaheuristicSolver <: AbstractSolver end
 
-approach(::MetaheuristicSolver) = :metaheuristic
+_approach(::MetaheuristicSolver) = :metaheuristic

--- a/src/minimize_bandwidth.jl
+++ b/src/minimize_bandwidth.jl
@@ -12,9 +12,28 @@ TODO: Write here
 function minimize_bandwidth(
     A::AbstractMatrix{T}, solver::AbstractSolver=DEFAULT_SOLVER
 ) where {T<:Number}
-    if !allequal(size(A))
-        throw(ArgumentError("Matrix bandwidth is not defined for non-square matrices"))
+    _assert_matrix_is_square(A)
+
+    if T !== Bool
+        A_bool = (!iszero).(A)
+    else
+        A_bool = copy(A)
     end
+
+    ordering = _bool_minimal_band_ordering(A_bool, solver)
+    A_reordered = A_bool[ordering, ordering]
+    bandwidth = bandwidth_unpermuted(A_reordered)
+
+    return BandwidthResult(A, bandwidth, ordering, solver)
+end
+
+"""
+    bandwidth_unpermuted(A) -> Int
+
+TODO: Write here
+"""
+function bandwidth_unpermuted(A::AbstractMatrix{T}) where {T<:Number}
+    _assert_matrix_is_square(A)
 
     if T !== Bool
         A_bool = (!iszero).(A)
@@ -22,10 +41,7 @@ function minimize_bandwidth(
         A_bool = A
     end
 
-    A_copy = copy(A_bool)
-    ordering = _sym_minimal_band_ordering(A_copy, solver)
-    A_reordered = A_bool[ordering, ordering]
-    indices = findall(A_reordered)
+    indices = findall(A_bool)
 
     if isempty(indices)
         bandwidth = 0
@@ -33,16 +49,14 @@ function minimize_bandwidth(
         bandwidth = maximum(abs(index[1] - index[2]) for index in indices)
     end
 
-    return BandwidthResult(A, bandwidth, ordering, solver)
+    return bandwidth
 end
 
-"""
-    _sym_minimal_bandwidh_ordering(A::AbstractMatrix{Bool}, solver::AbstractSolver)
-        -> Vector{Int}
-
-TODO: Write here
-"""
-function _sym_minimal_band_ordering(::AbstractMatrix{Bool}, ::T) where {T<:AbstractSolver}
+#= Compute a minimal bandwidth ordering for a preprocessed `AbstractMatrix{Bool}`.
+Restricting entries to booleans can improve performance via cache optimizations, bitwise
+operations, etc. Each concrete `AbstractSolver` subtype must implement its own
+`_bool_minimal_band_ordering` method to define the corresponding algorithm logic. =#
+function _bool_minimal_band_ordering(::AbstractMatrix{Bool}, ::T) where {T<:AbstractSolver}
     S = supertype(T)
 
     if S === AbstractSolver

--- a/src/types.jl
+++ b/src/types.jl
@@ -11,12 +11,9 @@ TODO: Write here
 """
 abstract type AbstractSolver end
 
-"""
-    approach(solver::AbstractSolver) -> Symbol
-
-TODO: Write here
-"""
-function approach(::T) where {T<:AbstractSolver}
+#= Indicate the category of solver (e.g., heuristic). Each concrete `AbstractSolver` subtype
+must implement its own `_approach` method for use in `BandwidthResult` instantiation. =#
+function _approach(::T) where {T<:AbstractSolver}
     S = supertype(T)
 
     if S === AbstractSolver
@@ -25,7 +22,7 @@ function approach(::T) where {T<:AbstractSolver}
         subtype = S
     end
 
-    throw(NotImplementedError(approach, :solver, subtype, AbstractSolver))
+    throw(NotImplementedError(_approach, :solver, subtype, AbstractSolver))
 end
 
 """
@@ -43,7 +40,7 @@ struct BandwidthResult{M<:AbstractMatrix{<:Number},S<:AbstractSolver}
     function BandwidthResult(
         matrix::M, bandwidth::Int, ordering::Vector{Int}, solver::S
     ) where {M<:AbstractMatrix{<:Number},S<:AbstractSolver}
-        return new{M,S}(matrix, bandwidth, ordering, solver, approach(solver))
+        return new{M,S}(matrix, bandwidth, ordering, solver, _approach(solver))
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -57,3 +57,54 @@ function Base.showerror(io::IO, e::NotImplementedError)
         Try defining method dispatch manually if this is a newly created subtype.""",
     )
 end
+
+"""
+    random_sparse_banded_matrix(n, k; p=0.75, rng=default_rng()) -> Matrix{Float64}
+
+TODO: Write here
+"""
+function random_sparse_banded_matrix(
+    n::Int, k::Int; p::Float64=0.75, rng::AbstractRNG=Random.default_rng()
+)
+    if n <= 0
+        throw(ArgumentError("Matrix order must be positive, got $n"))
+    end
+
+    if k < 0
+        throw(ArgumentError("Matrix bandwidth must be non-negative, got $k"))
+    end
+
+    if n <= k
+        throw(ArgumentError("Matrix order must be greater than bandwidth, got $n and $k"))
+    end
+
+    if !(0 < p <= 1)
+        throw(ArgumentError("Band density must be in (0, 1], got $p"))
+    end
+
+    A = zeros(Float64, n, n)
+
+    #= Ensure that each band has at least one nonzero entry. (The `is_upper` flag indicates
+    whether we are filling a superdiagonal or subdiagonal.) =#
+    for offset in 0:k, is_upper in (true, false)
+        rows = ((1 + offset):n) .- is_upper * offset
+        cols = (1:(n - offset)) .+ is_upper * offset
+        idx = rand(rng, 1:length(rows))
+        A[rows[idx], cols[idx]] = rand(rng)
+    end
+
+    for i in 1:n, j in max(1, i - k):(min(n, i + k))
+        if rand(rng) < p
+            A[i, j] = rand(rng)
+        end
+    end
+
+    return A
+end
+
+# TODO: Add comment above
+function _assert_matrix_is_square(A::AbstractMatrix{T}) where {T<:Number}
+    if !allequal(size(A))
+        throw(ArgumentError("Matrix bandwidth is not defined for non-square matrices"))
+    end
+end


### PR DESCRIPTION
Finish all docstrings (including doctests and examples) for the `Heuristic` module, along with several References. Modify the overall formatting and design within `src/` to be consistent with this.

Note that documentation of some core `MatrixBandwidth` names themselves (e.g., `minimize_bandwidth`) is yet to be completed.

Given that logic, documentation, and tests are now all done for both `CuthillMcKee` and `ReverseCuthillMcKee`, this PR completes the **Heuristic** section of issue #4.