### PR TITLE
Fix References rendering for private API

### DIFF
--- a/docs/src/private_api.md
+++ b/docs/src/private_api.md
@@ -14,4 +14,8 @@ Modules = [MatrixBandwidth, MatrixBandwidth.Exact, MatrixBandwidth.Heuristic, Ma
 Public = false
 ```
 
-<!-- TODO: Insert a References section here once citations are added -->
+## References
+
+```@bibliography
+Pages = [@__FILE__]
+```


### PR DESCRIPTION
We previously forgot to create a References section for the private API page of the documentation website. This PR fixes that issue.