### PR TITLE
Override `Base.show` for `BandwidthResult`

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -59,4 +59,16 @@ end
 
 Base.summary(res::BandwidthResult) = summary(res.solver)
 
-# TODO: Override `Base.show(io::IO, res::BandwidthResult)`
+# The `Base.show` override here takes heavy inspiration from the `Optim.jl` package
+function Base.show(io::IO, res::BandwidthResult)
+    n = size(res.matrix, 1)
+
+    println(io, "Results of Matrix Bandwidth Minimization")
+    println(io, " * Algorithm: $(summary(res.solver))")
+    println(io, " * Approach: $(titlecase(string(res.approach)))")
+    println(io, " * Minimum bandwidth: $(res.bandwidth)")
+    println(io, " * Original bandwidth: $(bandwidth(res.matrix))")
+    print(io, " * Matrix size: $n×$n")
+
+    return nothing
+end


### PR DESCRIPTION
This PR overrides `Base.show` for our output `BandwidthResult` struct, taking heavy inspiration from the `Optim.jl` package. We also modify all completed solver doctests (just CM and RCM so far) accordingly to showcase the display.