### PR TITLE
Remove redundant result computation in doctests

### DIFF
--- a/src/heuristic/cuthill_mckee.jl
+++ b/src/heuristic/cuthill_mckee.jl
@@ -67,7 +67,7 @@ julia> bandwidth(A)
 julia> bandwidth(A_shuffled) # Much larger after shuffling
 31
 
-julia> res = minimize_bandwidth(A_shuffled, CuthillMcKee()) # Finds the true minimum!
+julia> res = minimize_bandwidth(A_shuffled, CuthillMcKee()) # Finds the true minimum
 Results of Matrix Bandwidth Minimization
  * Algorithm: Cuthill–McKee algorithm
  * Approach: Heuristic
@@ -179,7 +179,7 @@ julia> bandwidth(A)
 julia> bandwidth(A_shuffled) # Much larger after shuffling
 170
 
-julia> res = minimize_bandwidth(A_shuffled, CuthillMcKee()) # Nearly the true minimum
+julia> res # Gets very close to the true minimum
 Results of Matrix Bandwidth Minimization
  * Algorithm: Cuthill–McKee algorithm
  * Approach: Heuristic

--- a/src/heuristic/reverse_cuthill_mckee.jl
+++ b/src/heuristic/reverse_cuthill_mckee.jl
@@ -65,7 +65,7 @@ julia> bandwidth(A)
 julia> bandwidth(A_shuffled) # Much larger after shuffling
 44
 
-julia> res = minimize_bandwidth(A_shuffled, ReverseCuthillMcKee()) # Finds the true minimum!
+julia> res = minimize_bandwidth(A_shuffled, ReverseCuthillMcKee()) # Finds the true minimum
 Results of Matrix Bandwidth Minimization
  * Algorithm: Reverse Cuthill–McKee algorithm
  * Approach: Heuristic
@@ -177,7 +177,7 @@ julia> bandwidth(A)
 julia> bandwidth(A_shuffled) # Much larger after shuffling
 239
 
-julia> res = minimize_bandwidth(A_shuffled, ReverseCuthillMcKee()) # Nearly the true minimum
+julia> res # Gets very close to the true minimum
 Results of Matrix Bandwidth Minimization
  * Algorithm: Reverse Cuthill–McKee algorithm
  * Approach: Heuristic


### PR DESCRIPTION
In the CM and RCM doctests with large sparse matrices, the `BandwidthResult` output is accidentally computed twice. This PR fixes that issue (and also removes exclamation marks from earlier on that make the lines too long).