### PR TITLE
Change 'at most'/'at least' k from italics to bold

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 *MatrixBandwidth.jl* offers several exact, heuristic, and metaheuristic algorithms for matrix bandwidth minimization.
 
-The *bandwidth* of a square matrix *A* is the minimum non-negative integer *k* &isin; **N** such that *A<sub>i,j</sub> = 0* whenever *|i - j| > k*. Equivalently, *A* has bandwidth *at most* *k* if all entries above the *k*<sup>th</sup> superdiagonal and below the *k*<sup>th</sup> subdiagonal are zero, and *A* has bandwidth *at least* *k* if there exists any nonzero entry in the *k*<sup>th</sup> superdiagonal or subdiagonal.
+The *bandwidth* of a square matrix *A* is the minimum non-negative integer *k* &isin; **N** such that *A<sub>i,j</sub>* = 0 whenever |*i* - *j*| > *k*. Equivalently, *A* has bandwidth **at most** *k* if all entries above the *k*<sup>th</sup> superdiagonal and below the *k*<sup>th</sup> subdiagonal are zero, and *A* has bandwidth **at least** *k* if there exists any nonzero entry in the *k*<sup>th</sup> superdiagonal or subdiagonal.
 
 *Matrix bandwidth minimization* is the problem of finding a permutation matrix *P* so that the bandwidth of *PAP*<sup>T</sup> is minimized; this is known to be NP-complete. Several heuristic algorithms (such as reverse Cuthill&ndash;McKee) run in polynomial time while still producing near-optimal orderings in practice, but exact methods (like MB-PS) are exponential in time complexity and thus only feasible for relatively small matrices.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -45,7 +45,7 @@ CurrentModule = MatrixBandwidth
 
 *MatrixBandwidth.jl* offers several exact, heuristic, and metaheuristic algorithms for matrix bandwidth minimization.
 
-The *bandwidth* of a square matrix ``A`` is the minimum non-negative integer ``k \in \mathbb{N}`` such that ``A_{i,j} = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth *at most* ``k`` if all entries above the ``k^\text{th}`` superdiagonal and below the ``k^\text{th}`` subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any nonzero entry in the ``k^\text{th}`` superdiagonal or subdiagonal.
+The *bandwidth* of a square matrix ``A`` is the minimum non-negative integer ``k \in \mathbb{N}`` such that ``A_{i,j} = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth **at most** ``k`` if all entries above the ``k^\text{th}`` superdiagonal and below the ``k^\text{th}`` subdiagonal are zero, and ``A`` has bandwidth **at least** ``k`` if there exists any nonzero entry in the ``k^\text{th}`` superdiagonal or subdiagonal.
 
 *Matrix bandwidth minimization* is the problem of finding a permutation matrix ``P`` so that the bandwidth of ``PAP^\mathsf{T}`` is minimized; this is known to be NP-complete. Several heuristic algorithms (such as reverse Cuthill–McKee) run in polynomial time while still producing near-optimal orderings in practice, but exact methods (like MB-PS) are exponential in time complexity and thus only feasible for relatively small matrices.
 

--- a/src/MatrixBandwidth.jl
+++ b/src/MatrixBandwidth.jl
@@ -10,9 +10,9 @@
 Exact, heuristic, and metaheuristic algorithms for matrix bandwidth minimization in Julia.
 
 The *bandwidth* of a square matrix ``A`` is the minimum non-negative integer ``k ∈ ℕ`` such
-that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth *at most*
+that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth **at most**
 ``k`` if all entries above the ``k``-th superdiagonal and below the ``k``-th subdiagonal are
-zero, and ``A`` has bandwidth *at least* ``k`` if there exists any nonzero entry in the
+zero, and ``A`` has bandwidth **at least** ``k`` if there exists any nonzero entry in the
 ``k``-th superdiagonal or subdiagonal.
 
 *Matrix bandwidth minimization* is the problem of finding a permutation matrix ``P`` so that

--- a/src/core.jl
+++ b/src/core.jl
@@ -10,9 +10,9 @@
 Minimize the matrix bandwidth of `A` using the algorithm defined by `solver`.
 
 The *bandwidth* of a square matrix ``A`` is the minimum non-negative integer ``k ∈ ℕ`` such
-that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth *at most*
+that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth **at most**
 ``k`` if all entries above the ``k``-th superdiagonal and below the ``k``-th subdiagonal are
-zero, and ``A`` has bandwidth *at least* ``k`` if there exists any nonzero entry in the
+zero, and ``A`` has bandwidth **at least** ``k`` if there exists any nonzero entry in the
 ``k``-th superdiagonal or subdiagonal.
 
 This function computes a (near-)optimal ordering ``π`` of the rows and columns of ``A`` so
@@ -89,9 +89,9 @@ end
 Compute the bandwidth of `A` without any permutations.
 
 The *bandwidth* of a square matrix ``A`` is the minimum non-negative integer ``k ∈ ℕ`` such
-that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth *at most*
+that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth **at most**
 ``k`` if all entries above the ``k``-th superdiagonal and below the ``k``-th subdiagonal are
-zero, and ``A`` has bandwidth *at least* ``k`` if there exists any nonzero entry in the
+zero, and ``A`` has bandwidth **at least** ``k`` if there exists any nonzero entry in the
 ``k``-th superdiagonal or subdiagonal.
 
 In contrast to [`minimize_bandwidth`](@ref), this function does not attempt to minimize the


### PR DESCRIPTION
This PR changes the 'at most' and 'at least' expressions preceding *k* in the definition of matrix bandwidth from italics to bold, avoiding confusion between emphasized text and the *k* in math mode. We do this in the README, in the Documenter docs, and in the in-code docstrings.