### PR TITLE
Change codecov badge from img.shields to official version

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <tr>
     <td>Code coverage</td>
     <td>
-      <a href="https://codecov.io/gh/Luis-Varona/MatrixBandwidth.jl"><img src="https://img.shields.io/codecov/c/gh/Luis-Varona/MatrixBandwidth.jl.svg?label=codecov" alt="Test coverage from codecov"></a>
+      <a href="https://codecov.io/gh/Luis-Varona/MatrixBandwidth.jl"><img src="https://codecov.io/gh/Luis-Varona/MatrixBandwidth.jl/branch/main/graph/badge.svg" alt="Test coverage from codecov"></a>
     </td>
     </tr>
     <tr>

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -28,7 +28,7 @@ CurrentModule = MatrixBandwidth
   <tr>
     <td>Code coverage</td>
     <td>
-      <a href="https://codecov.io/gh/Luis-Varona/MatrixBandwidth.jl"><img src="https://img.shields.io/codecov/c/gh/Luis-Varona/MatrixBandwidth.jl.svg?label=codecov" alt="Test coverage from codecov"></a>
+      <a href="https://codecov.io/gh/Luis-Varona/MatrixBandwidth.jl"><img src="https://codecov.io/gh/Luis-Varona/MatrixBandwidth.jl/branch/main/graph/badge.svg" alt="Test coverage from codecov"></a>
     </td>
     </tr>
     <tr>


### PR DESCRIPTION
Using the img.shields.io version of the codecov badge, it previously did not render properly on some mobile apps/browsers. This PR changes the badge to codecov's official version (both in the README and on our Documenter-generated website), fixing the issue.