### PR TITLE
RCM has the same bandwidth as CM

### DIFF
--- a/src/Heuristic/cuthill_mckee.jl
+++ b/src/Heuristic/cuthill_mckee.jl
@@ -38,9 +38,10 @@ matrix, which runs counter to our desire to provide a bandwidth minimization API
 indeed consider supporting this more performant implementation for sparse matrices.)
 
 It was found in [Geo71; pp. 114--15](@cite) that reversing the ordering produced by
-Cuthill–McKee tends to induce a more optimal bandwidth. This so-called *reverse
-Cuthill–McKee* variant is preferred in almost all cases—see [`ReverseCuthillMcKee`](@ref)
-and the associated method of `_bool_minimal_band_ordering` for our implementation.
+Cuthill–McKee tends to induce a more optimal *matrix profile* (a measure of how far, on
+average, nonzero entries are from the diagonal). This so-called *reverse Cuthill–McKee*
+variant is preferred in almost all cases—see [`ReverseCuthillMcKee`](@ref) and the
+associated method of `_bool_minimal_band_ordering` for our implementation.
 
 # Examples
 Cuthill–McKee finds an optimal ordering for an asymmetric ``35×35`` matrix whose rows and

--- a/src/Heuristic/reverse_cuthill_mckee.jl
+++ b/src/Heuristic/reverse_cuthill_mckee.jl
@@ -16,7 +16,8 @@ effective when ``A`` is sparse, this heuristic typically produces an ordering wh
 a matrix bandwidth either equal to or very close to the true minimum
 [CM69; pp. 157--58](@cite). The reverse Cuthill–McKee algorithm simply reverses the ordering
 produced by application of Cuthill–McKee; it was found in [Geo71; pp. 114--15](@cite) that
-this tends to induce an even more optimal bandwidth.
+although the bandwidth remains the same, this tends to produce a more optimal *matrix
+profile* (a measure of how far, on average, nonzero entries are from the diagonal).
 
 We also extend the algorithm to work more generally when ``A`` is not symmetric by applying
 it to ``A + Aᵀ`` instead, as suggested in [RS06; p. 808](@cite). This approach still tends


### PR DESCRIPTION
Previous iterations of the Cuthill-McKee and reverse Cuthill-McKee documentation/tests stated that RCM often produces a more optimal bandwidth than CM. This is not true--it is simply the matrix profile (not the matrix bandwidth). We have made the according modifications.