### PR TITLE
MB-ID solver; other minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ The latest citation information may be found in the [CITATION.bib](https://raw.g
 
 ## Project status
 
-I aim to release the first stable version of *MatrixBandwidth.jl* in late June 2025. The current version is a work-in-progress, with much of the API still under development.
+I aim to release the first stable version of *MatrixBandwidth.jl* in early July 2025. The current version is a work-in-progress, with much of the API still under development.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -88,7 +88,7 @@ The latest citation information may be found in the [CITATION.bib](https://raw.g
 
 ## Project status
 
-I aim to release the first stable version of *MatrixBandwidth.jl* in late June 2025. The current version is a work-in-progress, with much of the API still under development.
+I aim to release the first stable version of *MatrixBandwidth.jl* in early July 2025. The current version is a work-in-progress, with much of the API still under development.
 
 ## Index
 

--- a/src/Exact/Exact.jl
+++ b/src/Exact/Exact.jl
@@ -9,6 +9,17 @@
 
 Exact solvers for matrix bandwidth minimization.
 
+Exact methods are those which guarantee an optimal ordering producing the true minimum
+bandwidth of a matrix. Since bandwidth minimization is an NP-complete problem, existing
+exact algorithms are, at best, exponential in time complexity—much worse than many
+polynomial-time heuristic approaches (e.g., reverse Cuthill–McKee). Such methods, therefore,
+are not feasible for large matrices, but they remain useful when precise solutions are
+required for small-to-medium-sized inputs (say, up to ``100×100``).
+
+The following exact algorithms are currently supported:
+- [`MBID`](@ref): Minimum bandwidth by iterative deepening (MB-ID)
+- [`MBPS`](@ref): Minimum bandwidth by perimeter search (MB-PS)
+
 This submodule is part of the
 [MatrixBandwidth.jl](https://github.com/Luis-Varona/MatrixBandwidth.jl) package.
 """

--- a/src/Exact/Exact.jl
+++ b/src/Exact/Exact.jl
@@ -26,7 +26,8 @@ This submodule is part of the
 module Exact
 
 #! format: off
-import ..AbstractSolver, ..NotImplementedError, .._approach, .._bool_minimal_band_ordering
+import ..AbstractSolver, ..NotImplementedError
+import .._approach, .._bool_minimal_band_ordering, .._symmetrize
 #! format: on
 
 export MBID, MBPS

--- a/src/Exact/mbid.jl
+++ b/src/Exact/mbid.jl
@@ -14,5 +14,70 @@ struct MBID <: ExactSolver end
 Base.summary(::MBID) = "Matrix bandwidth by iterative deepening"
 
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::MBID)
+    n = size(A, 1)
+    adj_lists = map(node -> findall(A[:, node]), 1:n)
+
+    function _add_node!(
+        ordering_buf::Vector{Int},
+        unselected::Set{Int},
+        adj_list::Set{Int},
+        bandwidth::Int,
+        depth::Int,
+    )
+        if depth == n
+            ordering = ordering_buf
+        else
+            if depth == 0
+                starting_node = minimum(unselected)
+            end
+
+            ordering = nothing
+            res = iterate(unselected)
+
+            while (isnothing(ordering) && !isnothing(res))
+                (node, state) = res
+
+                if depth > 0 || node == starting_node
+                    ordering_buf[depth + 1] = node
+                    unselected_new = setdiff(unselected, [node])
+                    adj_list_new = union(adj_list, adj_lists[node])
+                    adj_list_new = intersect(adj_list_new, unselected_new)
+
+                    if _is_compatible(A, ordering_buf, adj_list_new, bandwidth, depth)
+                        ordering = _add_node!(
+                            ordering_buf, unselected_new, adj_list_new, bandwidth, depth + 1
+                        )
+                    end
+                end
+
+                res = iterate(unselected, state)
+            end
+        end
+
+        return ordering
+    end
+
+    ordering = nothing
+    ordering_buf = Vector{Int}(undef, n)
+    bandwidth = ceil(Int, maximum(length, adj_lists) / 2)
+
+    while isnothing(ordering)
+        unselected = Set(1:n)
+        adj_list = Set{Int}()
+        ordering = _add_node!(ordering_buf, unselected, adj_list, bandwidth, 0)
+        bandwidth += 1
+    end
+
+    return ordering
+end
+
+function _is_compatible(
+    A::AbstractMatrix{Bool},
+    ordering::Vector{Int},
+    adj_list::Set{Int},
+    bandwidth::Int,
+    depth::Int,
+)
     # TODO: Implement
+    return true # Just a placeholder
 end

--- a/src/Exact/mbid.jl
+++ b/src/Exact/mbid.jl
@@ -13,9 +13,10 @@ struct MBID <: ExactSolver end
 
 Base.summary(::MBID) = "Matrix bandwidth by iterative deepening"
 
-function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::MBID)
+function _bool_minimal_band_ordering(S::AbstractMatrix{Bool}, ::MBID)
     n = size(A, 1)
-    adj_lists = map(node -> findall(A[:, node]), 1:n)
+    A_sym = _symmetrize(A)
+    adj_lists = map(node -> findall(A_sym[:, node]), 1:n)
 
     function _add_node!(
         ordering_buf::Vector{Int},
@@ -43,7 +44,7 @@ function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::MBID)
                     adj_list_new = union(adj_list, adj_lists[node])
                     adj_list_new = intersect(adj_list_new, unselected_new)
 
-                    if _is_compatible(A, ordering_buf, adj_list_new, bandwidth, depth)
+                    if _is_compatible(A_sym, ordering_buf, adj_list_new, bandwidth, depth)
                         ordering = _add_node!(
                             ordering_buf, unselected_new, adj_list_new, bandwidth, depth + 1
                         )
@@ -72,7 +73,7 @@ function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::MBID)
 end
 
 function _is_compatible(
-    A::AbstractMatrix{Bool},
+    A_sym::AbstractMatrix{Bool},
     ordering::Vector{Int},
     adj_list::Set{Int},
     bandwidth::Int,

--- a/src/Exact/mbps.jl
+++ b/src/Exact/mbps.jl
@@ -11,10 +11,49 @@ TODO: Write here
 """
 struct MBPS <: ExactSolver
     depth::Int
+
+    MBPS() = new(0)
+
+    function MBPS(depth::Int)
+        if depth < 0
+            throw(ArgumentError("MB-PS depth parameter must be positive, got $depth"))
+        end
+
+        return new(depth)
+    end
 end
 
 Base.summary(::MBPS) = "Matrix bandwidth by perimeter search"
 
+function _optimal_mbps_depth(A::AbstractMatrix{Bool})
+    n = size(A, 1)
+
+    # I'm really not sure about this... let's check the original paper again
+    if n <= 2
+        return 1
+    elseif n <= 10
+        return 3
+    elseif n <= 20
+        return 4
+    elseif n <= 50
+        return 5
+    elseif n <= 60
+        return 7
+    elseif n <= 80
+        return 6
+    else
+        # TODO: Maybe implement sparsity-based heuristics?
+    end
+end
+
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, solver::MBPS)
+    depth = solver.depth
+
+    if depth == 0
+        depth = _optimal_mbps_depth(A)
+    end
+
     # TODO: Implement
+
+    return Int[] # Just a placeholder
 end

--- a/src/Exact/types.jl
+++ b/src/Exact/types.jl
@@ -5,9 +5,16 @@
 # distributed except according to those terms.
 
 """
-    ExactSolver <: AbstractSolver
+    Exact <: AbstractSolver
 
-TODO: Write here
+Abstract type for all exact matrix bandwidth minimization solvers.
+
+Exact methods are those which guarantee an optimal ordering producing the true minimum
+bandwidth of a matrix. Since bandwidth minimization is an NP-complete problem, existing
+exact algorithms are, at best, exponential in time complexity—much worse than many
+polynomial-time heuristic approaches (e.g., reverse Cuthill–McKee). Such methods, therefore,
+are not feasible for large matrices, but they remain useful when precise solutions are
+required for small-to-medium-sized inputs (say, up to ``100×100``).
 """
 abstract type ExactSolver <: AbstractSolver end
 

--- a/src/Heuristic/Heuristic.jl
+++ b/src/Heuristic/Heuristic.jl
@@ -28,7 +28,8 @@ This submodule is part of the
 module Heuristic
 
 #! format: off
-import ..AbstractSolver, ..NotImplementedError, .._approach, .._bool_minimal_band_ordering
+import ..AbstractSolver, ..NotImplementedError
+import .._approach, .._bool_minimal_band_ordering, .._symmetrize
 #! format: on
 
 using DataStructures: Queue, enqueue!, dequeue!

--- a/src/Heuristic/cuthill_mckee.jl
+++ b/src/Heuristic/cuthill_mckee.jl
@@ -208,13 +208,8 @@ end
 Base.summary(::CuthillMcKee) = "Cuthill–McKee algorithm"
 
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, solver::CuthillMcKee)
-    if A != A'
-        A_sym = A .|| A'
-    else
-        A_sym = A
-    end
-
-    n = size(A_sym, 1)
+    n = size(A, 1)
+    A_sym = _symmetrize(A)
     A_sym[1:(n + 1):end] .= false
 
     node_selector = solver.node_selector

--- a/src/Metaheuristic/Metaheuristic.jl
+++ b/src/Metaheuristic/Metaheuristic.jl
@@ -15,7 +15,8 @@ This submodule is part of the
 module Metaheuristic
 
 #! format: off
-import ..AbstractSolver, ..NotImplementedError, .._approach, .._bool_minimal_band_ordering
+import ..AbstractSolver, ..NotImplementedError
+import .._approach, .._bool_minimal_band_ordering
 #! format: on
 
 export SimulatedAnnealing, GeneticAlgorithm, GRASP

--- a/src/core.jl
+++ b/src/core.jl
@@ -59,6 +59,11 @@ function minimize_bandwidth(
         A_bool = (!iszero).(A)
     end
 
+    #= Any simultaneous row and column permutation preserves diagonal entries, so we set the
+    diagonal of `A_bool` to false for simplicity and for consistency with any solvers (e.g.,
+    MB-ID) that utilize an assumed adjacency matrix structure. =#
+    foreach(i -> A_bool[i, i] = false, axes(A_bool, 1))
+
     bandwidth_orig = bandwidth(A_bool)
 
     # If `A` is already diagonal/empty, no possible ordering can improve its bandwidth

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -188,3 +188,14 @@ function _assert_matrix_is_square(A::AbstractMatrix{T}) where {T<:Number}
         throw(ArgumentError("Matrix bandwidth is not defined for non-square matrices"))
     end
 end
+
+# TODO: Summarize here
+function _symmetrize(A::AbstractMatrix{Bool})
+    if A != A'
+        A_sym = A .|| A'
+    else
+        A_sym = A
+    end
+
+    return A_sym
+end


### PR DESCRIPTION
This PR finishes the logic for the MB-ID solver in the `MatrixBandwidth.Exact` submodule. We also note that the symmetrization of the input matrix originally contained within the reverse Cuthill&ndash;McKee solver is again needed, so we extract the logic into a `_symmetrize` helper function in `src/utils.jl` for common use, importing it in all three submodules (`MatrixBandwidth.Exact`, `MatrixBandwidth.Heuristic`, and `MatrixBandwidth.Metaheuristic`). (Looking at issue #25, however, we may change this part of the API anyway, requiring symmetric input in the first place and letting users pick their own symmetrization strategy, at least for the nonzero support.)

We also change the expected date for our first stable release (in the documentation and the README) from late June 2025 to early July, given several minor delays in development.

(Note that unit tests and documentation for the MB-ID solver are not yet done; we shall address this in a subsequent PR. We also start briefly on the logic for the MB-PS solver but leave it largely unfinished.)