### PR TITLE
Fix/flesh out bandwidth docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@
 
 *MatrixBandwidth.jl* offers several algorithms for matrix bandwidth minimization and matrix bandwidth recognition.
 
-The *bandwidth* of a square matrix *A* is the minimum non-negative integer *k* &isin; **N** such that *A<sub>i,j</sub>* = 0 whenever |*i* - *j*| > *k*. Equivalently, *A* has bandwidth *at most* *k* if all entries above the *k*<sup>th</sup> superdiagonal and below the *k*<sup>th</sup> subdiagonal are zero, and *A* has bandwidth *at least* *k* if there exists any nonzero entry in the *k*<sup>th</sup> superdiagonal or subdiagonal.
+The *bandwidth* of an *n*&times;*n* matrix *A* is the minimum non-negative integer *k* &isin; [0, *n* - 1] such that *A<sub>i,j</sub>* = 0 whenever |*i* - *j*| > *k*. Equivalently, *A* has bandwidth *at most* *k* if all entries above the *k*<sup>th</sup> superdiagonal and below the *k*<sup>th</sup> subdiagonal are zero, and *A* has bandwidth *at least* *k* if there exists any nonzero entry in the *k*<sup>th</sup> superdiagonal or subdiagonal.
 
-The *matrix bandwidth minimization problem* involves finding a permutation matrix *P* such that the bandwidth of *PAP*<sup>T</sup> is minimized; this is known to be NP-complete. Several heuristic algorithms (such as reverse Cuthill&ndash;McKee) run in polynomial time while still producing near-optimal orderings in practice, but exact methods (like MB-PS) are exponential in time complexity and thus are only feasible for relatively small matrices.
+The *matrix bandwidth minimization problem* involves finding a permutation matrix *P* such that the bandwidth of *PAP*<sup>T</sup> is minimized; this is known to be NP-complete. Several heuristic algorithms (such as reverse Cuthill&ndash;McKee) run in polynomial time while still producing near-optimal orderings in practice, but exact methods (like Caprara&ndash;Salazar-González) are exponential in time complexity and thus are only feasible for relatively small matrices.
 
-On the other hand, the *matrix bandwidth recognition problem* entails determining whether there exists a permutation matrix *P* such that the bandwidth of *PAP*<sup>T</sup> is at most some fixed integer non-negative integer *k* &isin; *N*&mdash;an optimal permutation that fully minimizes the bandwidth of *A* is not required. Unlike the NP-hard minimization problem, this is decidable in *O*(*n*<sup>*k*</sup>) time, where *n* is the order of *A*.
+On the other hand, the *matrix bandwidth recognition problem* entails determining whether there exists a permutation matrix *P* such that the bandwidth of *PAP*<sup>T</sup> is at most some fixed integer non-negative integer *k* &isin; *N*&mdash;an optimal permutation that fully minimizes the bandwidth of *A* is not required. Unlike the NP-hard minimization problem, this is decidable in *O*(*n*<sup>*k*</sup>) time.
 
 ## Algorithms
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -45,11 +45,11 @@ CurrentModule = MatrixBandwidth
 
 *MatrixBandwidth.jl* offers several algorithms for matrix bandwidth minimization and matrix bandwidth recognition.
 
-The *bandwidth* of a square matrix ``A`` is the minimum non-negative integer ``k \in \mathbb{N}`` such that ``A_{i,j} = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth *at most* ``k`` if all entries above the ``k^\text{th}`` superdiagonal and below the ``k^\text{th}`` subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any nonzero entry in the ``k^\text{th}`` superdiagonal or subdiagonal.
+The *bandwidth* of an ``n \times n`` matrix ``A`` is the minimum non-negative integer ``k \in [0, n - 1]`` such that ``A_{i,j} = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth *at most* ``k`` if all entries above the ``k^\text{th}`` superdiagonal and below the ``k^\text{th}`` subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any nonzero entry in the ``k^\text{th}`` superdiagonal or subdiagonal.
 
-The *matrix bandwidth minimization problem* involves finding a permutation matrix ``P`` such that the bandwidth of ``PAP^\mathsf{T}`` is minimized; this is known to be NP-complete. Several heuristic algorithms (such as reverse Cuthill–McKee) run in polynomial time while still producing near-optimal orderings in practice, but exact methods (like MB-PS) are exponential in time complexity and thus are only feasible for relatively small matrices.
+The *matrix bandwidth minimization problem* involves finding a permutation matrix ``P`` such that the bandwidth of ``PAP^\mathsf{T}`` is minimized; this is known to be NP-complete. Several heuristic algorithms (such as reverse Cuthill–McKee) run in polynomial time while still producing near-optimal orderings in practice, but exact methods (like Caprara–Salazar-González) are exponential in time complexity and thus are only feasible for relatively small matrices.
 
-On the other hand, the *matrix bandwidth recognition problem* entails determining whether there exists a permutation matrix ``P`` such that the bandwidth of ``PAP^\mathsf{T}`` is at most some fixed integer non-negative integer ``k \in \mathbb{N}``—an optimal permutation that fully minimizes the bandwidth of ``A`` is not required. Unlike the NP-hard minimization problem, this is decidable in ``O(n^k)`` time, where ``n`` is the order of ``A``.
+On the other hand, the *matrix bandwidth recognition problem* entails determining whether there exists a permutation matrix ``P`` such that the bandwidth of ``PAP^\mathsf{T}`` is at most some fixed integer non-negative integer ``k \in \mathbb{N}``—an optimal permutation that fully minimizes the bandwidth of ``A`` is not required. Unlike the NP-hard minimization problem, this is decidable in ``O(n^k)`` time.
 
 ## Algorithms
 

--- a/src/MatrixBandwidth.jl
+++ b/src/MatrixBandwidth.jl
@@ -11,11 +11,11 @@
 
 Fast algorithms for matrix bandwidth minimization and matrix bandwidth recognition in Julia.
 
-The *bandwidth* of a square matrix ``A`` is the minimum non-negative integer ``k ∈ ℕ`` such
-that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth *at most*
-``k`` if all entries above the ``k``-th superdiagonal and below the ``k``-th subdiagonal are
-zero, and ``A`` has bandwidth *at least* ``k`` if there exists any nonzero entry in the
-``k``-th superdiagonal or subdiagonal.
+The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
+``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
+has bandwidth *at most* ``k`` if all entries above the ``k``-th superdiagonal and below the
+``k``-th subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
+nonzero entry in the ``k``-th superdiagonal or subdiagonal.
 
 The *matrix bandwidth minimization problem* involves finding a permutation matrix ``P`` such
 that the bandwidth of ``PAPᵀ`` is minimized; this is known to be NP-complete. Several
@@ -28,7 +28,7 @@ On the other hand, the *matrix bandwidth recognition problem* entails determinin
 there exists a permutation matrix ``P`` such that the bandwidth of ``PAPᵀ`` is at most some
 fixed non-negative integer ``k ∈ ℕ``—an optimal permutation that fully minimizes the
 bandwidth of ``A`` is not required. Unlike the NP-hard minimization problem, this is
-decidable in ``O(nᵏ)`` time, where ``n`` is the order of ``A``.
+decidable in ``O(nᵏ)`` time.
 
 The following algorithms are currently supported:
 - **Minimization**

--- a/src/Minimization/Minimization.jl
+++ b/src/Minimization/Minimization.jl
@@ -9,11 +9,11 @@
 
 Exact, heuristic, and metaheuristic algorithms for matrix bandwidth minimization in Julia.
 
-The *bandwidth* of a square matrix ``A`` is the minimum non-negative integer ``k ∈ ℕ`` such
-that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth *at most*
-``k`` if all entries above the ``k``-th superdiagonal and below the ``k``-th subdiagonal are
-zero, and ``A`` has bandwidth *at least* ``k`` if there exists any nonzero entry in the
-``k``-th superdiagonal or subdiagonal.
+The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
+``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
+has bandwidth *at most* ``k`` if all entries above the ``k``-th superdiagonal and below the
+``k``-th subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
+nonzero entry in the ``k``-th superdiagonal or subdiagonal.
 
 The *matrix bandwidth minimization problem* involves finding a permutation matrix ``P`` such
 that the bandwidth of ``PAPᵀ`` is minimized; this is known to be NP-complete. Several

--- a/src/Minimization/core.jl
+++ b/src/Minimization/core.jl
@@ -9,11 +9,11 @@
 
 Minimize the bandwidth of `A` using the algorithm defined by `solver`.
 
-The *bandwidth* of a square matrix ``A`` is the minimum non-negative integer ``k ∈ ℕ`` such
-that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth *at most*
-``k`` if all entries above the ``k``-th superdiagonal and below the ``k``-th subdiagonal are
-zero, and ``A`` has bandwidth *at least* ``k`` if there exists any nonzero entry in the
-``k``-th superdiagonal or subdiagonal.
+The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
+``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
+has bandwidth *at most* ``k`` if all entries above the ``k``-th superdiagonal and below the
+``k``-th subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
+nonzero entry in the ``k``-th superdiagonal or subdiagonal.
 
 This function computes a (near-)optimal ordering ``π`` of the rows and columns of ``A`` so
 that the bandwidth of ``PAPᵀ`` is minimized, where ``P`` is the permutation matrix
@@ -30,8 +30,8 @@ complexity and thus only feasible for relatively small matrices.
     a full list of supported solvers.)
 
 # Returns
-- `::MinimizationResult`: a struct containing the original matrix `A`, the minimized
-    bandwidth, the (near-)optimal ordering of the rows and columns, and the algorithm used.
+- `::MinimizationResult`: a struct containing the algorithm used, the original matrix `A`,
+    the (near-)optimal ordering of the rows and columns, and the minimized bandwidth.
 
 # Examples
 [TODO: Add here once more solvers are implemented]

--- a/src/Recognition/Recognition.jl
+++ b/src/Recognition/Recognition.jl
@@ -9,17 +9,17 @@
 
 Algorithms for matrix bandwidth recognition in Julia.
 
-The *bandwidth* of a square matrix ``A`` is the minimum non-negative integer ``k ∈ ℕ`` such
-that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth *at most*
-``k`` if all entries above the ``k``-th superdiagonal and below the ``k``-th subdiagonal are
-zero, and ``A`` has bandwidth *at least* ``k`` if there exists any nonzero entry in the
-``k``-th superdiagonal or subdiagonal.
+The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
+``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
+has bandwidth *at most* ``k`` if all entries above the ``k``-th superdiagonal and below the
+``k``-th subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
+nonzero entry in the ``k``-th superdiagonal or subdiagonal.
 
 The *matrix bandwidth recognition problem* entails determining whether there exists a
 permutation matrix ``P`` such that the bandwidth of ``PAPᵀ`` is at most some fixed
 non-negative integer ``k ∈ ℕ``—an optimal permutation that fully minimizes the bandwidth of
 ``A`` is not required. Unlike the NP-hard minimization problem, this is decidable in
-``O(nᵏ)`` time, where ``n`` is the order of ``A``.
+``O(nᵏ)`` time.
 
 The following algorithms are currently supported:
 - Caprara–Salazar-González algorithm ([`CapraraSalazarGonzalez`](@ref))

--- a/src/Recognition/core.jl
+++ b/src/Recognition/core.jl
@@ -9,13 +9,23 @@
 
 Determine whether `A` has bandwidth at most `k` using the algorithm defined by `decider`.
 
-The *bandwidth* of a square matrix ``A`` is the minimum non-negative integer ``k ∈ ℕ`` such
-that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth *at most*
-``k`` if all entries above the ``k``-th superdiagonal and below the ``k``-th subdiagonal are
-zero, and ``A`` has bandwidth *at least* ``k`` if there exists any nonzero entry in the
-``k``-th superdiagonal or subdiagonal.
+The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
+``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
+has bandwidth *at most* ``k`` if all entries above the ``k``-th superdiagonal and below the
+``k``-th subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
+nonzero entry in the ``k``-th superdiagonal or subdiagonal.
 
-This function [TODO: Write here]
+Given some fixed non-negative integer `k`, this function determines (with 100% certainty)
+whether there exists some ordering ``π`` of the rows and columns of ``A`` such that the
+bandwidth of ``PAPᵀ`` is at most `k`, where ``P`` is the permutation matrix corresponding to
+``π``. This is known to be decidable in ``O(nᵏ)`` time, although some deciders (e.g.,
+[`CapraraSalazarGonzalez`](@ref)) run in exponential time instead to produce even quicker
+runtimes in practice.
+
+If ``k ≥ n - 1``, then this function immediately answers in the affirmative, since the
+maximum possible bandwidth of an ``n×n`` matrix is ``n - 1``. After this initial check, a
+preliminary lower bound on the bandwidth is computed in ``O(n³)`` time using results from
+Caprara and Salazar-González (2005). If this lower bound is greater than ``k```
 
 # Arguments
 - `A::AbstractMatrix{<:Number}`: the (square) matrix whose bandwidth is tested.
@@ -25,7 +35,9 @@ This function [TODO: Write here]
     for a full list of supported deciders.)
 
 # Returns
-- `::RecognitionResult`: TODO: Write here
+- `::RecognitionResult`: a struct containing the algorithm used, the original matrix `A`,
+    the identified ordering of the rows and columns (if one exists), the threshold bandwidth
+    `k`, and a boolean indicating whether the ordering exists.
 
 # Examples
 [TODO: Add here once more deciders are implemented]

--- a/src/core.jl
+++ b/src/core.jl
@@ -9,11 +9,11 @@
 
 Compute the bandwidth of `A` before any permutation of its rows and columns.
 
-The *bandwidth* of a square matrix ``A`` is the minimum non-negative integer ``k ∈ ℕ`` such
-that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth *at most*
-``k`` if all entries above the ``k``-th superdiagonal and below the ``k``-th subdiagonal are
-zero, and ``A`` has bandwidth *at least* ``k`` if there exists any nonzero entry in the
-``k``-th superdiagonal or subdiagonal.
+The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
+``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
+has bandwidth *at most* ``k`` if all entries above the ``k``-th superdiagonal and below the
+``k``-th subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
+nonzero entry in the ``k``-th superdiagonal or subdiagonal.
 
 In contrast to [`minimize_bandwidth`](@ref), this function does not attempt to minimize the
 bandwidth of `A` by permuting its rows and columns—it simply computes its bandwidth as is.
@@ -106,11 +106,11 @@ Compute a lower bound on the bandwidth of `A` using [CSG05](@cite)'s results.
 The nonzero support of `A` is assumed to be symmetric, since [CSG05](@cite)'s bound was
 discovered in the context of undirected graphs (whose adjacency matrices are symmetric).
 
-The *bandwidth* of a square matrix ``A`` is the minimum non-negative integer ``k ∈ ℕ`` such
-that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth *at most*
-``k`` if all entries above the ``k``-th superdiagonal and below the ``k``-th subdiagonal are
-zero, and ``A`` has bandwidth *at least* ``k`` if there exists any nonzero entry in the
-``k``-th superdiagonal or subdiagonal.
+The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
+``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
+has bandwidth *at most* ``k`` if all entries above the ``k``-th superdiagonal and below the
+``k``-th subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
+nonzero entry in the ``k``-th superdiagonal or subdiagonal.
 
 In contrast to [`minimize_bandwidth`](@ref), this function does not attempt to truly
 minimize the bandwidth of `A`—it simply returns a lower bound on its bandwidth up to


### PR DESCRIPTION
Reworded the bandwidth + problem definitions in the README, Documenter docs, and module/core function docstrings. Also fixed the 'minimize_bandwidth' and 'has_bandwidth_k_ordering' docstrings (although examples are still missing until more algorithms are implemented).