### PR TITLE
Fix 'integer non-negative integer' typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The *bandwidth* of an *n*&times;*n* matrix *A* is the minimum non-negative integ
 
 The *matrix bandwidth minimization problem* involves finding a permutation matrix *P* such that the bandwidth of *PAP*<sup>T</sup> is minimized; this is known to be NP-complete. Several heuristic algorithms (such as reverse Cuthill&ndash;McKee) run in polynomial time while still producing near-optimal orderings in practice, but exact methods (like Caprara&ndash;Salazar-González) are exponential in time complexity and thus are only feasible for relatively small matrices.
 
-On the other hand, the *matrix bandwidth recognition problem* entails determining whether there exists a permutation matrix *P* such that the bandwidth of *PAP*<sup>T</sup> is at most some fixed integer non-negative integer *k* &isin; *N*&mdash;an optimal permutation that fully minimizes the bandwidth of *A* is not required. Unlike the NP-hard minimization problem, this is decidable in *O*(*n*<sup>*k*</sup>) time.
+On the other hand, the *matrix bandwidth recognition problem* entails determining whether there exists a permutation matrix *P* such that the bandwidth of *PAP*<sup>T</sup> is at most some fixed non-negative integer *k* &isin; *N*&mdash;an optimal permutation that fully minimizes the bandwidth of *A* is not required. Unlike the NP-hard minimization problem, this is decidable in *O*(*n*<sup>*k*</sup>) time.
 
 ## Algorithms
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -49,7 +49,7 @@ The *bandwidth* of an ``n \times n`` matrix ``A`` is the minimum non-negative in
 
 The *matrix bandwidth minimization problem* involves finding a permutation matrix ``P`` such that the bandwidth of ``PAP^\mathsf{T}`` is minimized; this is known to be NP-complete. Several heuristic algorithms (such as reverse Cuthill–McKee) run in polynomial time while still producing near-optimal orderings in practice, but exact methods (like Caprara–Salazar-González) are exponential in time complexity and thus are only feasible for relatively small matrices.
 
-On the other hand, the *matrix bandwidth recognition problem* entails determining whether there exists a permutation matrix ``P`` such that the bandwidth of ``PAP^\mathsf{T}`` is at most some fixed integer non-negative integer ``k \in \mathbb{N}``—an optimal permutation that fully minimizes the bandwidth of ``A`` is not required. Unlike the NP-hard minimization problem, this is decidable in ``O(n^k)`` time.
+On the other hand, the *matrix bandwidth recognition problem* entails determining whether there exists a permutation matrix ``P`` such that the bandwidth of ``PAP^\mathsf{T}`` is at most some fixed non-negative integer ``k \in \mathbb{N}``—an optimal permutation that fully minimizes the bandwidth of ``A`` is not required. Unlike the NP-hard minimization problem, this is decidable in ``O(n^k)`` time.
 
 ## Algorithms
 


### PR DESCRIPTION
This PR changes the recurring 'integer non-negative integer' typo in README.md and docs/src/index.md to simply 'non-negative integer'.