### PR TITLE
Fix type hierarchies in docstrings

### DIFF
--- a/src/Minimization/Exact/solvers/caprara_salazar_gonzalez.jl
+++ b/src/Minimization/Exact/solvers/caprara_salazar_gonzalez.jl
@@ -5,7 +5,7 @@
 # distributed except according to those terms.
 
 """
-    CapraraSalazarGonzalez <: ExactSolver <: AbstractSolver
+    CapraraSalazarGonzalez <: ExactSolver <: AbstractSolver <: AbstractAlgorithm
 
 TODO: Write here
 """

--- a/src/Minimization/Exact/solvers/del_corso_manzini.jl
+++ b/src/Minimization/Exact/solvers/del_corso_manzini.jl
@@ -5,7 +5,7 @@
 # distributed except according to those terms.
 
 """
-    DelCorsoManzini <: ExactSolver <: AbstractSolver
+    DelCorsoManzini <: ExactSolver <: AbstractSolver <: AbstractAlgorithm
 
 TODO: Write here
 """

--- a/src/Minimization/Exact/solvers/del_corso_manzini_with_ps.jl
+++ b/src/Minimization/Exact/solvers/del_corso_manzini_with_ps.jl
@@ -5,7 +5,7 @@
 # distributed except according to those terms.
 
 """
-    DelCorsoManziniWithPS <: ExactSolver <: AbstractSolver
+    DelCorsoManziniWithPS <: ExactSolver <: AbstractSolver <: AbstractAlgorithm
 
 TODO: Write here
 """

--- a/src/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
+++ b/src/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
@@ -5,7 +5,7 @@
 # distributed except according to those terms.
 
 """
-    SaxeGurariSudborough <: ExactSolver <: AbstractSolver
+    SaxeGurariSudborough <: ExactSolver <: AbstractSolver <: AbstractAlgorithm
 
 TODO: Write here
 """

--- a/src/Minimization/Exact/types.jl
+++ b/src/Minimization/Exact/types.jl
@@ -5,7 +5,7 @@
 # distributed except according to those terms.
 
 """
-    Exact <: AbstractSolver <: AbstractAlgorithm
+    ExactSolver <: AbstractSolver <: AbstractAlgorithm
 
 Abstract type for all exact matrix bandwidth minimization solvers.
 

--- a/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
+++ b/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
@@ -5,7 +5,7 @@
 # distributed except according to those terms.
 
 """
-    CuthillMcKee <: HeuristicSolver <: AbstractSolver
+    CuthillMcKee <: HeuristicSolver <: AbstractSolver <: AbstractAlgorithm
 
 The *Cuthill–McKee algorithm* is a heuristic method for minimizing the bandwidth of a
 symmetric matrix ``A``. It considers the graph ``G(A)`` whose adjacency matrix is ``A``

--- a/src/Minimization/Heuristic/solvers/gibbs_poole_stockmeyer.jl
+++ b/src/Minimization/Heuristic/solvers/gibbs_poole_stockmeyer.jl
@@ -5,7 +5,7 @@
 # distributed except according to those terms.
 
 """
-    GibbsPooleStockmeyer <: HeuristicSolver <: AbstractSolver
+    GibbsPooleStockmeyer <: HeuristicSolver <: AbstractSolver <: AbstractAlgorithm
 
 TODO: Write here. Do we need a node selector?
 """

--- a/src/Minimization/Heuristic/solvers/reverse_cuthill_mckee.jl
+++ b/src/Minimization/Heuristic/solvers/reverse_cuthill_mckee.jl
@@ -5,7 +5,7 @@
 # distributed except according to those terms.
 
 """
-    ReverseCuthillMcKee <: HeuristicSolver <: AbstractSolver
+    ReverseCuthillMcKee <: HeuristicSolver <: AbstractSolver <: AbstractAlgorithm
 
 The *reverse Cuthill–McKee algorithm* is a variant of the *Cuthill–McKee algorithm*—a
 heuristic method for minimizing the bandwidth of a symmetric matrix ``A``. Cuthill–McKee

--- a/src/Minimization/Metaheuristic/solvers/genetic_algorithm.jl
+++ b/src/Minimization/Metaheuristic/solvers/genetic_algorithm.jl
@@ -5,7 +5,7 @@
 # distributed except according to those terms.
 
 """
-    GeneticAlgorithm <: MetaheuristicSolver <: AbstractSolver
+    GeneticAlgorithm <: MetaheuristicSolver <: AbstractSolver <: AbstractAlgorithm
 
 TODO: Write here
 """

--- a/src/Minimization/Metaheuristic/solvers/grasp.jl
+++ b/src/Minimization/Metaheuristic/solvers/grasp.jl
@@ -5,7 +5,7 @@
 # distributed except according to those terms.
 
 """
-    GRASP <: MetaheuristicSolver <: AbstractSolver
+    GRASP <: MetaheuristicSolver <: AbstractSolver <: AbstractAlgorithm
 
 TODO: Write here
 """

--- a/src/Minimization/Metaheuristic/solvers/simulated_annealing.jl
+++ b/src/Minimization/Metaheuristic/solvers/simulated_annealing.jl
@@ -5,7 +5,7 @@
 # distributed except according to those terms.
 
 """
-    SimulatedAnnealing <: MetaheuristicSolver <: AbstractSolver
+    SimulatedAnnealing <: MetaheuristicSolver <: AbstractSolver <: AbstractAlgorithm
 
 TODO: Write here
 """

--- a/src/Recognition/deciders/caprara_salazar_gonzalez.jl
+++ b/src/Recognition/deciders/caprara_salazar_gonzalez.jl
@@ -5,7 +5,7 @@
 # distributed except according to those terms.
 
 """
-    CapraraSalazarGonzalez <: AbstractDecider
+    CapraraSalazarGonzalez <: AbstractDecider <: AbstractAlgorithm
 
 TODO: Write here
 """

--- a/src/Recognition/deciders/del_corso_manzini.jl
+++ b/src/Recognition/deciders/del_corso_manzini.jl
@@ -5,7 +5,7 @@
 # distributed except according to those terms.
 
 """
-    DelCorsoManzini <: AbstractDecider
+    DelCorsoManzini <: AbstractDecider <: AbstractAlgorithm
 
 TODO: Write here
 """

--- a/src/Recognition/deciders/del_corso_manzini_with_ps.jl
+++ b/src/Recognition/deciders/del_corso_manzini_with_ps.jl
@@ -5,7 +5,7 @@
 # distributed except according to those terms.
 
 """
-    DelCorsoManziniWithPS <: AbstractDecider
+    DelCorsoManziniWithPS <: AbstractDecider <: AbstractAlgorithm
 
 TODO: Write here
 """

--- a/src/Recognition/deciders/saxe_gurari_sudborough.jl
+++ b/src/Recognition/deciders/saxe_gurari_sudborough.jl
@@ -5,7 +5,7 @@
 # distributed except according to those terms.
 
 """
-    SaxeGurariSudborough <: AbstractDecider
+    SaxeGurariSudborough <: AbstractDecider <: AbstractAlgorithm
 
 TODO: Write here
 """


### PR DESCRIPTION
This PR makes sure that all subtypes have docstrings specifying their whole type hierarchies in the summary. It also fixes the docstring for 'ExactSolver', which incorrectly specified the struct name as just 'Exact'.