### PR TITLE
Add docstrings; fix test info

### DIFF
--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -29,6 +29,16 @@
   url = {https://doi.org/10.1287/ijoc.1040.0083},
 }
 
+@article{DCM99,
+  author = {Del Corso, G. M. and Manzini, G.},
+  journal = {*Computing*},
+  title = {Finding Exact Solutions to the Bandwidth Minimization Problem},
+  volume = {62},
+  year = {1999},
+  pages = {189--203},
+  url = {https://doi.org/10.1007/s006070050002},
+}
+
 @phdthesis{Geo71,
   author = {George, J. Alan},
   school = {Department of Computer Science, Stanford University},

--- a/src/MatrixBandwidth.jl
+++ b/src/MatrixBandwidth.jl
@@ -73,7 +73,8 @@ top level due to name conflicts between `Minimization` and `Recognition`. =#
 export Minimization, Recognition
 
 #= Core exports: the original bandwidth (before any reordering) and an `O(n³)` lower bound
-from Caprara and Salazar-González (2005). (This bound is not tight.) =#
+from Caprara and Salazar-González (2005). (This bound is tight in many non-trivial cases
+but not universally so.) =#
 export bandwidth, bandwidth_lower_bound
 
 #= `Minimization` and `Recognition` exports: the core bandwidth minimization and recognition

--- a/src/Minimization/Exact/solvers/caprara_salazar_gonzalez.jl
+++ b/src/Minimization/Exact/solvers/caprara_salazar_gonzalez.jl
@@ -7,7 +7,31 @@
 """
     CapraraSalazarGonzalez <: ExactSolver <: AbstractSolver <: AbstractAlgorithm
 
-TODO: Write here
+The *Caprara–Salazar-González minimization algorithm* is an exact method for minimizing the
+bandwidth of a structurally symmetric matrix ``A``. For a fixed ``k ∈ ℕ``, the algorithm
+performs a bidirectional depth-first search of all partial orderings of the rows and columns
+of ``A``, adding indices one at a time to both the left and right ends. Partial orderings
+are pruned not only by ensuring that adjacent pairs of currently placed indices are within
+``k`` of each other but also by employing a branch-and-bound framework with lower bounds on
+bandwidtth compatibility computed via integer linear programming relaxations. This search is
+repeated with incrementing values of ``k`` until a bandwidth-``k`` ordering is found
+[CSG05](@cite), with ``k`` initialized to some lower bound on the minimum bandwidth of ``A``
+up to symmetric permutation.
+
+Specifically, this implementation of the Caprara–Salazar-González algorithm uses the
+``min(α(A), γ(A))`` lower bound from the original paper [CSG05; pp. 359--60](@cite) as the
+initial value of ``k``. (Further implementation details can be found in the source code for
+[`bandwidth_lower_bound`](@ref).)
+
+As noted above, the Caprara–Salazar-González algorithm requires structurally symmetric input
+(that is, ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is nonzero for
+``1 ≤ i, j ≤ n``).
+
+# Performance
+[TODO: Write here]
+
+# Examples
+[TODO: Write here]
 """
 struct CapraraSalazarGonzalez <: ExactSolver end
 

--- a/src/Minimization/Exact/solvers/del_corso_manzini.jl
+++ b/src/Minimization/Exact/solvers/del_corso_manzini.jl
@@ -7,7 +7,54 @@
 """
     DelCorsoManzini <: ExactSolver <: AbstractSolver <: AbstractAlgorithm
 
-TODO: Write here
+The *Del Corso–Manzini minimization algorithm* is an exact method for minimizing the
+bandwidth of a structurally symmetric matrix ``A``. For a fixed ``k ∈ ℕ``, the algorithm
+performs a depth-first search of all partial orderings of the rows and columns of ``A``,
+adding indices one at a time. Partial orderings are pruned not only by ensuring that
+adjacent pairs of currently placed indices are within ``k`` of each other but also by
+tracking the latest positions at which the remaining indices can be placed. This search is
+repeated with incrementing values of ``k`` until a bandwidth-``k`` ordering is found
+[DCM99](@cite), with ``k`` initialized to some lower bound on the minimum bandwidth of ``A``
+up to symmetric permutation.
+
+Specifically, this implementation of the Del Corso–Manzini algorithm uses the
+``min(α(A), γ(A))`` lower bound from [CSG05; pp. 359--60](@cite) as the initial value of
+``k``. (Further implementation details can be found in the source code for
+[`bandwidth_lower_bound`](@ref).) This improves upon the original algorithm, which used the
+maximum number of nonzero off-diagonal entries in a single row as a lower bound on the
+minimum bandwidth of ``A`` up to symmetric permutation [DCM99; p. 192--93](@cite).
+
+As noted above, the Del Corso–Manzini algorithm requires structurally symmetric input (that
+is, ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is nonzero for ``1 ≤ i, j ≤ n``).
+
+# Performance
+Given an ``n×n`` input matrix ``A``, the Del Corso–Manzini algorithm runs in
+``O(n³ ⋅ n!)`` time:
+- For each underlying "bandwidth ≤ ``k``" check, we perform a depth-first search of
+    ``O(n!)`` partial orderings.
+- Checking plausibility of each partial ordering takes ``O(nk)`` time, resulting in
+    ``O(nk ⋅ n!)`` steps for each value of ``k``.
+- The difference between the maximum possible bandwidth (``n - 1``) and our initial lower
+    bound grows linearly in ``n``, so we run the underlying ``O(nk ⋅ n!)`` recognition
+    algorithm ``O(n)`` times.
+- Finally, ``∑ₖ₌₀ⁿ⁻¹ nk = O(n³)``, so the overall time complexity is ``O(n³ ⋅ n!)``.
+
+Of course, this is but an upper bound on the time complexity of Del Corso–Manzini, achieved
+only in the most pathological of cases. In practice, efficient pruning techniques and
+compatibility checks—along with [CSG05; pp. 359--60](@cite)'s relatively tight initial lower
+bound on the minimum bandwidth—result in approximately exponential growth in time complexity
+with respect to ``n``.
+
+Based on experimental results, the algorithm is feasible for ``n×n`` matrices up to
+``n ≈ 100`` or so.
+
+# Examples
+[TODO: Write here]
+
+# Notes
+For readers of the original paper, what we call the Del Corso–Manzini minimization algorithm
+here is designated the "MB-ID algorithm" in [DCM99; p. 191](@cite). The so-called "MB-PS
+algorithm," on the other hand, we implement in [`Minimization.DelCorsoManziniWithPS`](@ref).
 """
 struct DelCorsoManzini <: ExactSolver end
 
@@ -18,7 +65,75 @@ _requires_symmetry(::DelCorsoManzini) = true
 """
     DelCorsoManziniWithPS{D} <: ExactSolver <: AbstractSolver <: AbstractAlgorithm
 
-TODO: Write here
+The *Del Corso–Manzini minimization algorithm with perimeter search* is an exact method for
+minimizing the bandwidth of a structurally symmetric matrix ``A``. The base Del
+Corso–Manzini algorithm performs a depth-first search of all partial orderings of the rows
+and columns of ``A`` for some fixed ``k ∈ ℕ``, adding indices one at a time. Partial
+orderings are pruned not only by ensuring that adjacent pairs of currently placed indices
+are within ``k`` of each other but also by tracking the latest positions at which the
+remaining indices can be placed. This search is repeated with incrementing values of ``k``
+until a bandwidth-``k`` ordering is found [DCM99](@cite), with ``k`` initialized to some
+lower bound on the minimum bandwidth of ``A`` up to symmetric permutation.
+
+The incorporation of perimeter search to this approach entails precomputing a "perimeter" of
+``d``-permutations of row indices of ``A``, where ``d`` is a positive integer passed as a
+parameter to the solver. Each permutation represents a way to select the last ``d`` entries
+of the ordering, and as the construction of the partial ordering progresses, potential
+endings are pruned to exclude those incompatible with already placed indices. In addition to
+pruning a potential ending if it contains indices already placed, compatibility is also
+checked via precomputed time stamps indicating, for each potential ending, a loose lower
+bound on the earliest position at which any given index can be placed should said ending be
+selected.
+
+Like our implementation of the base Del Corso–Manzini algorithm (see
+[`Minimization.DelCorsoManzini`](@ref)), this implementation uses the
+``min(α(A), γ(A))`` lower bound from [CSG05; pp. 359--60](@cite) as the initial value of
+``k``. (Further implementation details can be found in the source code for
+[`bandwidth_lower_bound`](@ref).) This improves upon the original algorithm, which used the
+maximum number of nonzero off-diagonal entries in a single row as a lower bound on the
+minimum bandwidth of ``A`` up to symmetric permutation [DCM99; p. 194](@cite).
+
+As noted above, the Del Corso–Manzini algorithm with perimeter search requires structurally
+symmetric input (that is, ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is
+nonzero for ``1 ≤ i, j ≤ n``).
+
+# Fields
+[TODO: Write here]
+
+# Constructors
+[TODO: Write here]
+
+# Performance
+Given an ``n×n`` input matrix ``A`` and perimeter search depth ``d``, the Del Corso–Manzini
+algorithm with perimeter search runs in ``O(nᴰ⁺¹ ⋅ n!)`` time, where ``Dᴰ = max(d, 2)``:
+- For each underlying "bandwidth ≤ ``k``" check, we perform a depth-first search of
+    ``O(n!)`` partial orderings.
+- Checking plausibility of each partial ordering takes ``O(nk)`` time, and checking
+    compatibility with all size-``d`` LPOs takes ``O(nᵈ)`` time. Thus, the overall time
+    complexity for each value of ``k`` is ``O((nᵈ + nk) ⋅ n!)``.
+- The difference between the maximum possible bandwidth (``n - 1``) and our initial lower
+    bound grows linearly in ``n``, so we run the underlying ``O((nᵈ + nk) ⋅ n!)``
+    recognition algorithm ``O(n)`` times.
+- Finally, ``∑ₖ₌₀ⁿ⁻¹ (nᵈ + nk) = O(nᵈ⁺¹ + n³)``, so the overall time complexity
+    is ``O(nᴰ⁺¹ ⋅ n!)``, where ``D = max(d, 2)``.
+
+Of course, this is but an upper bound on the time complexity of Del Corso–Manzini with
+perimeter search, achieved only in the most pathological of cases. In practice, efficient
+pruning techniques and compatibility checks—along with [CSG05; pp. 359--60](@cite)'s
+relatively tight initial lower bound on the minimum bandwidth—result in approximately
+exponential growth in time complexity with respect to ``n``.
+
+Based on experimental results, the algorithm is feasible for ``n×n`` matrices up to
+``n ≈ 100`` or so.
+
+# Examples
+[TODO: Write here]
+
+# Notes
+For readers of the original paper, what we call the Del Corso–Manzini minimization algorithm
+with perimeter search here is designated the "MB-PS algorithm" in [DCM99; p. 193](@cite).
+The so-called "MB-ID algorithm," on the other hand, we implement in
+[`Minimization.DelCorsoManzini`](@ref).
 """
 struct DelCorsoManziniWithPS{D<:Union{Nothing,Int}} <: ExactSolver
     depth::D
@@ -37,6 +152,8 @@ end
 Base.summary(::DelCorsoManziniWithPS) = "Del Corso–Manzini with perimeter search"
 
 _requires_symmetry(::DelCorsoManziniWithPS) = true
+
+# TODO: Add inline comments to all the code in the rest of the file below
 
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::DelCorsoManzini)
     n = size(A, 1)
@@ -96,7 +213,7 @@ function _bool_minimal_band_ordering(
     ordering = nothing
 
     while isnothing(ordering)
-        perimeter = map(lpo -> (lpo, Recognition._lpo_time_stamps(lpo, A, k)), lpos)
+        perimeter = map(lpo -> (lpo, Recognition._dcm_lpo_time_stamps(lpo, A, k)), lpos)
         ordering = Recognition._dcm_add_node!(
             ordering_buf,
             A,

--- a/src/Minimization/Exact/solvers/del_corso_manzini.jl
+++ b/src/Minimization/Exact/solvers/del_corso_manzini.jl
@@ -54,7 +54,7 @@ Based on experimental results, the algorithm is feasible for ``n×n`` matrices u
 # Notes
 For readers of the original paper, what we call the Del Corso–Manzini minimization algorithm
 here is designated the "MB-ID algorithm" in [DCM99; p. 191](@cite). The so-called "MB-PS
-algorithm," on the other hand, we implement in [`Minimization.DelCorsoManziniWithPS`](@ref).
+algorithm," on the other hand, we implement in [`DelCorsoManziniWithPS`](@ref).
 """
 struct DelCorsoManzini <: ExactSolver end
 
@@ -86,12 +86,12 @@ bound on the earliest position at which any given index can be placed should sai
 selected.
 
 Like our implementation of the base Del Corso–Manzini algorithm (see
-[`Minimization.DelCorsoManzini`](@ref)), this implementation uses the
-``min(α(A), γ(A))`` lower bound from [CSG05; pp. 359--60](@cite) as the initial value of
-``k``. (Further implementation details can be found in the source code for
-[`bandwidth_lower_bound`](@ref).) This improves upon the original algorithm, which used the
-maximum number of nonzero off-diagonal entries in a single row as a lower bound on the
-minimum bandwidth of ``A`` up to symmetric permutation [DCM99; p. 194](@cite).
+[`DelCorsoManzini`](@ref)), this implementation uses the ``min(α(A), γ(A))`` lower bound
+from [CSG05; pp. 359--60](@cite) as the initial value of ``k``. (Further implementation
+details can be found in the source code for [`bandwidth_lower_bound`](@ref).) This improves
+upon the original algorithm, which used the maximum number of nonzero off-diagonal entries
+in a single row as a lower bound on the minimum bandwidth of ``A`` up to symmetric
+permutation [DCM99; p. 194](@cite).
 
 As noted above, the Del Corso–Manzini algorithm with perimeter search requires structurally
 symmetric input (that is, ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is
@@ -133,7 +133,7 @@ Based on experimental results, the algorithm is feasible for ``n×n`` matrices u
 For readers of the original paper, what we call the Del Corso–Manzini minimization algorithm
 with perimeter search here is designated the "MB-PS algorithm" in [DCM99; p. 193](@cite).
 The so-called "MB-ID algorithm," on the other hand, we implement in
-[`Minimization.DelCorsoManzini`](@ref).
+[`DelCorsoManzini`](@ref).
 """
 struct DelCorsoManziniWithPS{D<:Union{Nothing,Int}} <: ExactSolver
     depth::D

--- a/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
+++ b/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
@@ -8,14 +8,15 @@
     CuthillMcKee <: HeuristicSolver <: AbstractSolver <: AbstractAlgorithm
 
 The *Cuthill–McKee algorithm* is a heuristic method for minimizing the bandwidth of a
-symmetric matrix ``A``. It considers the graph ``G(A)`` whose adjacency matrix is ``A``
-(ignoring self-loops) and performs a breadth-first search of each connected component of
-``G(A)``, starting from a low-degree node then visiting its neighbors in order of increasing
-degree. Particularly effective when ``A`` is sparse, this heuristic typically produces an
-ordering which induces a matrix bandwidth either equal to or very close to the true minimum
-[CM69; pp. 157--58](@cite).
+structurally symmetric matrix ``A``. It considers the graph ``G(A)`` whose adjacency matrix
+is ``A`` (ignoring weights and self-loops) and performs a breadth-first search of each
+connected component of ``G(A)``, starting from a low-degree node then visiting its neighbors
+in order of increasing degree. Particularly effective when ``A`` is sparse, this heuristic
+typically produces an ordering which induces a matrix bandwidth either equal to or very
+close to the true minimum [CM69; pp. 157--58](@cite).
 
-As noted above, the input matrix must be symmetric for Cuthill–McKee to work.
+As noted above, the Cuthill–McKee algorithm requires structurally symmetric input (that is,
+``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is nonzero for ``1 ≤ i, j ≤ n``).
 
 # Fields
 - `node_selector::Function`: a function that selects a node from some connected component of
@@ -210,18 +211,20 @@ _requires_symmetry(::CuthillMcKee) = true
     ReverseCuthillMcKee <: HeuristicSolver <: AbstractSolver <: AbstractAlgorithm
 
 The *reverse Cuthill–McKee algorithm* is a variant of the *Cuthill–McKee algorithm*—a
-heuristic method for minimizing the bandwidth of a symmetric matrix ``A``. Cuthill–McKee
-considers the graph ``G(A)`` whose adjacency matrix is ``A`` (ignoring self-loops) and
-performs a breadth-first search of each connected component of ``G(A)``, starting from a
-low-degree node then visiting its neighbors in order of increasing degree. Particularly
-effective when ``A`` is sparse, this heuristic typically produces an ordering which induces
-a matrix bandwidth either equal to or very close to the true minimum
+heuristic method for minimizing the bandwidth of a structurally symmetric matrix ``A``.
+Cuthill–McKee considers the graph ``G(A)`` whose adjacency matrix is ``A`` (ignoring weights
+and self-loops) and performs a breadth-first search of each connected component of ``G(A)``,
+starting from a low-degree node then visiting its neighbors in order of increasing degree.
+Particularly effective when ``A`` is sparse, this heuristic typically produces an ordering
+which induces a matrix bandwidth either equal to or very close to the true minimum
 [CM69; pp. 157--58](@cite). The reverse Cuthill–McKee algorithm simply reverses the ordering
 produced by application of Cuthill–McKee; it was found in [Geo71; pp. 114--15](@cite) that
 although the bandwidth remains the same, this tends to produce a more optimal *matrix
 profile* (a measure of how far, on average, nonzero entries are from the diagonal).
 
-As noted above, the input matrix must be symmetric for reverse Cuthill–McKee to work.
+As noted above, the reverse Cuthill–McKee algorithm requires structurally symmetric input
+(that is, ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is nonzero for
+``1 ≤ i, j ≤ n``).
 
 # Performance
 Given an ``n×n`` input matrix ``A``, the reverse Cuthill–McKee algorithm runs in ``O(n²)``

--- a/src/Recognition/deciders/caprara_salazar_gonzalez.jl
+++ b/src/Recognition/deciders/caprara_salazar_gonzalez.jl
@@ -7,7 +7,33 @@
 """
     CapraraSalazarGonzalez <: AbstractDecider <: AbstractAlgorithm
 
-TODO: Write here
+The *Caprara–Salazar-González recognition algorithm* is a method for determining, given some
+fixed ``k ∈ ℕ``, whether a structurally symmetric matrix ``A`` has a bandwidth at most ``k``
+up to symmetric permutation. The algorithm performs a bidirectional depth-first search of
+all partial orderings of the rows and columns of ``A``, adding indices one at a time to both
+the left and right ends. Partial orderings are pruned not only by ensuring that adjacent
+pairs of currently placed indices are within ``k`` of each other but also by employing a
+branch-and-bound framework with lower bounds on bandwidtth compatibility computed via
+integer linear programming relaxations. This search is repeated with incrementing values of
+``k`` until a bandwidth-``k`` ordering is found [CSG05](@cite), with ``k`` initialized to
+some lower bound on the minimum bandwidth of ``A`` up to symmetric permutation.
+
+As noted above, the Caprara–Salazar-González algorithm requires structurally symmetric input
+(that is, ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is nonzero for
+``1 ≤ i, j ≤ n``).
+
+# Performance
+[TODO: Write here]
+
+# Examples
+[TODO: Write here]
+
+# Notes
+This algorithm is not the main one described in the original paper [CSG05](@cite), which
+actually never explicitly presents a procedure for matrix bandwidth recognition. However,
+the paper does define a bandwidth minimization algorithm that repeatedly calls a recognition
+subroutine—this is precisely the logic we implement here. (We do, however, also implement
+said minimization algorithm in [`Minimization.CapraraSalazarGonzalez`](@ref).)
 """
 struct CapraraSalazarGonzalez <: AbstractDecider end
 

--- a/src/Recognition/deciders/caprara_salazar_gonzalez.jl
+++ b/src/Recognition/deciders/caprara_salazar_gonzalez.jl
@@ -33,7 +33,8 @@ This algorithm is not the main one described in the original paper [CSG05](@cite
 actually never explicitly presents a procedure for matrix bandwidth recognition. However,
 the paper does define a bandwidth minimization algorithm that repeatedly calls a recognition
 subroutine—this is precisely the logic we implement here. (We do, however, also implement
-said minimization algorithm in [`Minimization.CapraraSalazarGonzalez`](@ref).)
+said minimization algorithm in
+[`MatrixBandwidth.Minimization.Exact.CapraraSalazarGonzalez`](@ref).)
 """
 struct CapraraSalazarGonzalez <: AbstractDecider end
 

--- a/src/Recognition/deciders/del_corso_manzini.jl
+++ b/src/Recognition/deciders/del_corso_manzini.jl
@@ -7,7 +7,48 @@
 """
     DelCorsoManzini <: AbstractDecider <: AbstractAlgorithm
 
-TODO: Write here
+The *Del Corso–Manzini recognition algorithm* is a method for determining, given some fixed
+``k ∈ ℕ``, whether a structurally symmetric matrix ``A`` has bandwidth at most ``k`` up to
+symmetric permutation. The algorithm performs a depth-first search of all partial orderings
+of the rows and columns of ``A``, adding indices one at a time. Partial orderings are pruned
+not only by ensuring that adjacent pairs of currently placed indices are within ``k`` of
+each other but also by tracking the latest positions at which the remaining indices can be
+placed [DCM99](@cite).
+
+As noted above, the Del Corso–Manzini algorithm requires structurally symmetric input (that
+is, ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is nonzero for ``1 ≤ i, j ≤ n``).
+
+# Performance
+Given an ``n×n`` input matrix ``A`` and threshold bandwidth ``k``, the Del Corso–Manzini
+algorithm runs in ``O(nk ⋅ n!)`` time:
+- We perform a depth-first search of ``O(n!)`` partial orderings.
+- Checking plausibility of each partial ordering takes ``O(nk)`` time.
+- Therefore, the overall time complexity is ``O(nk ⋅ n!)``.
+
+Of course, this is but an upper bound on the time complexity of Del Corso–Manzini, achieved
+only in the most pathological of cases. In practice, efficient pruning techniques and
+compatibility checks result in approximately exponential growth in time complexity with
+respect to ``n``.
+
+Based on experimental results, the algorithm is feasible for ``n×n`` matrices up to
+``n ≈ 100`` or so.
+
+# Examples
+[TODO: Write here]
+
+# Notes
+For readers of the original paper, what we call the Del Corso–Manzini recognition algorithm
+here is essentially a wrapper around the underlying `AddNode` subroutine in what
+[DCM99; p. 191](@cite) terms the "MB-ID algorithm" for bandwidth minimization (not mere
+recognition). MB-ID (which we also implement in [`Minimization.DelCorsoManzini`](@ref))
+calls this recognition procedure with incrementing values of ``k`` until a bandwidth-``k``
+ordering is found, with ``k`` initialized to some lower bound on the minimum bandwidth of
+``A`` up to symmetric permutation.
+
+[DCM99; p. 193](@cite) also describes an "MB-PS algorithm" for bandwidth minimization,
+which we implement in [`Minimization.DelCorsoManziniWithPS`](@ref). Similarly, the
+underlying recognition subroutine for MB-PS is implemented in
+[`Recognition.DelCorsoManziniWithPS`](@ref).
 """
 struct DelCorsoManzini <: AbstractDecider end
 
@@ -18,7 +59,68 @@ _requires_symmetry(::DelCorsoManzini) = true
 """
     DelCorsoManziniWithPS{D} <: AbstractDecider <: AbstractAlgorithm
 
-TODO: Write here
+The *Del Corso–Manzini recognition algorithm with perimeter search* is a method for
+determining, given some fixed ``k ∈ ℕ``, whether a structurally symmetric matrix ``A`` has
+bandwidth at most ``k`` up to symmetric permutation. The base Del Corso–Manzini algorithm
+performs a depth-first search of all partial orderings of the rows and columns of ``A``,
+adding indices one at a time. Partial orderings are pruned not only by ensuring that
+adjacent pairs of currently placed indices are within ``k`` of each other but also by
+tracking the latest positions at which the remaining indices can be placed [DCM99](@cite).
+
+The incorporation of perimeter search to this approach entails precomputing a "perimeter" of
+``d``-permutations of row indices of ``A``, where ``d`` is a positive integer passed as a
+parameter to the solver. Each permutation represents a way to select the last ``d`` entries
+of the ordering, and as the construction of the partial ordering progresses, potential
+endings are pruned to exclude those incompatible with already placed indices. In addition to
+pruning a potential ending if it contains indices already placed, compatibility is also
+checked via precomputed time stamps indicating, for each potential ending, a loose lower
+bound on the earliest position at which any given index can be placed should said ending be
+selected.
+
+As noted above, the Del Corso–Manzini algorithm with perimeter search requires structurally
+symmetric input (that is, ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is
+nonzero for ``1 ≤ i, j ≤ n``).
+
+# Fields
+[TODO: Write here]
+
+# Constructors
+[TODO: Write here]
+
+# Performance
+Given an ``n×n`` input matrix ``A``, perimeter search depth ``d``, and threshold bandwidth
+``k``, the Del Corso–Manzini algorithm with perimeter search runs in ``O(max(nᵈ, nk) ⋅ n!)``
+time:
+- We perform a depth-first search of ``O(n!)`` partial orderings.
+- Checking plausibility of each partial ordering takes ``O(nk)`` time, and checking
+    compatibility with all size-``d`` LPOs takes ``O(nᵈ)`` time. Thus, the overall time
+    complexity for each value of ``k`` is ``O((nᵈ + nk) ⋅ n!)``.
+- Therefore, the overall time complexity is ``O(max(nᵈ, nk) ⋅ n!)``.
+
+Of course, this is but an upper bound on the time complexity of Del Corso–Manzini with
+perimeter search, achieved only in the most pathological of cases. In practice, efficient
+pruning techniques and compatibility checks result in approximately exponential growth in
+time complexity with respect to ``n``.
+
+Based on experimental results, the algorithm is feasible for ``n×n`` matrices up to
+``n ≈ 100`` or so.
+
+# Examples
+[TODO: Write here]
+
+# Notes
+For readers of the original paper, what we call the Del Corso–Manzini recognition algorithm
+with perimeter search here is essentially a wrapper around the underlying `AddNode1` and
+`Prune` subroutines in what [DCM99; p. 193](@cite) terms the "MB-PS algorithm" for bandwidth
+minimization (not mere recognition). MB-PS (which we also implement in
+[`Minimization.DelCorsoManziniWithPS`](@ref)) calls this recognition procedure with
+incrementing values of ``k`` until a bandwidth-``k`` ordering is found, with ``k``
+initialized to some lower bound on the minimum bandwidth of ``A`` up to symmetric
+permutation.
+
+[DCM99; p. 191](@cite) also describes an "MB-ID algorithm" for bandwidth minimization, which
+we implement in [`Minimization.DelCorsoManzini`](@ref). Similarly, the underlying
+recognition subroutine for MB-ID is implemented in [`Recognition.DelCorsoManzini`](@ref).
 """
 struct DelCorsoManziniWithPS{D<:Union{Nothing,Int}} <: AbstractDecider
     depth::D
@@ -38,7 +140,8 @@ Base.summary(::DelCorsoManziniWithPS) = "Del Corso–Manzini with perimeter sear
 
 _requires_symmetry(::DelCorsoManziniWithPS) = true
 
-# TODO: Comment here
+# TODO: Add inline comments to all the code in the rest of the file below
+
 function _dcm_ps_optimal_depth(A::AbstractMatrix{Bool})
     n = size(A, 1)
 
@@ -104,8 +207,8 @@ function _bool_bandwidth_k_ordering(
     num_placed = 0
     ps_depth = decider.depth
     perimeter = [
-        (lpo, _lpo_time_stamps(lpo, A, k)) for node_subset in combinations(1:n, ps_depth)
-        for lpo in permutations(node_subset)
+        (lpo, _dcm_lpo_time_stamps(lpo, A, k)) for
+        node_subset in combinations(1:n, ps_depth) for lpo in permutations(node_subset)
     ]
 
     return _dcm_add_node!(
@@ -130,6 +233,21 @@ function _dcm_add_node!(
 
     n = size(A, 1)
 
+    #= The original Del Corso and Manzini (1999) paper makes two bold claims:
+    - Once `num_placed` reaches `n - ps_depth`, only one LPO will remain in `perimeter`.
+    - This LPO will, by construction, be compatible with the current partial ordering under
+        the bandwidth-`k` constraint.
+
+    On both counts, the paper is wrong. The second claim assumes perfect pruning of the
+    perimeter at each step, but the paper itself admits that this is infeasible, ultimately
+    espousing the simplified version implemented here. The first claim, on the other hand,
+    is never justified by the paper under *any* conditions—after all, many partial orderings
+    of length `n - ps_depth` may allow multiple permutations of the remaining `ps_depth`
+    indices without violating the bandwidth constraint.
+
+    Therefore, we refrain from automatically filling up the remaining positions and
+    returning early when `num_placed` reaches `n - ps_depth` (as the paper suggests),
+    instead opting to continue the search until `num_placed` reaches `n`. =#
     if num_placed == n
         return ordering_buf
     end
@@ -147,49 +265,34 @@ function _dcm_add_node!(
         )
             unselected_new = setdiff(unselected, [candidate])
 
-            #= If `num_placed` is zero and we check `ordering_buf[1] < max_last_label`, we
-            risk erroneous behavior if `ordering_buf[1]` is initialized to a value greater
-            than or equal to `max_last_label` (e.g., when using `UndefInitializer()`). =#
-            if num_placed == 0
-                first_label = candidate
-            else
-                first_label = ordering_buf[1]
+            if _dcm_no_ps_is_reversed(
+                ordering_buf, unselected_new, num_placed, ps_depth, candidate
+            )
+                continue
             end
 
-            # `max_label` is maximum possible label of the last node that may be placed
-            if isempty(unselected_new)
-                max_last_label = candidate
-            else
-                max_last_label = maximum(unselected_new)
-            end
+            perimeter_new = _dcm_pruned_perimeter(
+                perimeter, candidate, num_placed, ps_depth, n
+            )
 
-            #= The ordering `i₁, i₂, … iₙ` induces the same bandwidth as `iₙ, iₙ₋₁, … i₁`, so
-            without loss of generality, we restrict our search to partial orderings such
-            that `i₁` is less than the maximum possible `iₙ`. =#
-            if first_label < max_last_label
-                perimeter_new = _dcm_pruned_perimeter(
-                    perimeter, candidate, num_placed, ps_depth
+            if !isempty(perimeter_new)
+                adj_list_new = intersect(
+                    union(adj_list, adj_lists[candidate]), unselected_new
                 )
 
-                if !isempty(perimeter_new)
-                    adj_list_new = intersect(
-                        union(adj_list, adj_lists[candidate]), unselected_new
+                if _dcm_is_compatible(ordering_buf, A, adj_list_new, k, num_placed)
+                    ordering_buf[num_placed + 1] = candidate
+                    ordering = _dcm_add_node!(
+                        ordering_buf,
+                        A,
+                        k,
+                        adj_lists,
+                        unselected_new,
+                        adj_list_new,
+                        perimeter_new,
+                        num_placed + 1,
+                        ps_depth,
                     )
-
-                    if _dcm_is_compatible(ordering_buf, A, adj_list_new, k, num_placed)
-                        ordering_buf[num_placed + 1] = candidate
-                        ordering = _dcm_add_node!(
-                            ordering_buf,
-                            A,
-                            k,
-                            adj_lists,
-                            unselected_new,
-                            adj_list_new,
-                            perimeter_new,
-                            num_placed + 1,
-                            ps_depth,
-                        )
-                    end
                 end
             end
         end
@@ -200,22 +303,95 @@ function _dcm_add_node!(
     return ordering
 end
 
+#= The ordering `i₁, i₂, … iₙ` induces the same bandwidth as `iₙ, iₙ₋₁, … i₁`, so without
+loss of generality, we restrict our search to partial orderings such that `i₁` is less than
+the maximum possible `iₙ`. =#
+function _dcm_no_ps_is_reversed(
+    ordering_buf::Vector{Int},
+    unselected::Set{Int},
+    num_placed::Int,
+    ps_depth::Int,
+    candidate::Int,
+)
+    # If perimeter search is enabled, this check is already handled in the pruning logic
+    if ps_depth > 0
+        return false
+    end
+
+    #= If `num_placed` is zero and we check `ordering_buf[1] < max_last_label`,
+    we risk erroneous behavior if `ordering_buf[1]` is initialized to some large
+    value (e.g., with `UndefInitializer()`). =#
+    if num_placed == 0
+        first_label = candidate
+    else
+        first_label = ordering_buf[1]
+    end
+
+    #= If `unselected` is empty, then `candidate` is already the last label, not some label
+    placed at an intermediate position that we can ignore. =#
+    if isempty(unselected)
+        max_last_label = candidate
+    else
+        max_last_label = maximum(unselected)
+    end
+
+    # There is no need to check for equality, since every label is unique
+    return max_last_label < first_label
+end
+
+function _dcm_lpo_time_stamps(lpo::Vector{Int}, A::AbstractMatrix{Bool}, k::Int)
+    n = size(A, 1)
+
+    time_stamps = zeros(Int, n)
+    d = length(lpo)
+    foreach(((i, node),) -> time_stamps[node] = n - d + i, enumerate(lpo))
+
+    queue = Queue{Int}()
+    foreach(node -> enqueue!(queue, node), lpo)
+
+    while !isempty(queue)
+        node = dequeue!(queue)
+        unvisited = filter!(neighbor -> time_stamps[neighbor] == 0, findall(A[:, node]))
+        time_stamps[unvisited] .= time_stamps[node] - k
+        foreach(neighbor -> enqueue!(queue, neighbor), unvisited)
+    end
+
+    return time_stamps
+end
+
 function _dcm_pruned_perimeter(
     perimeter::Vector{Tuple{Vector{Int},Vector{Int}}},
     candidate::Int,
     num_placed::Int,
     search_depth::Int,
+    n::Int,
 )
     if search_depth == 0
         perimeter_new = perimeter
     else
-        perimeter_new = filter(
-            ((_, time_stamp),) -> time_stamp[candidate] <= num_placed + 1, perimeter
-        )
+        perimeter_new = copy(perimeter)
 
+        #= The ordering `i₁, i₂, … iₙ` induces the same bandwidth as `iₙ, iₙ₋₁, … i₁`, so
+        without loss of generality, we restrict our search to partial orderings such that
+        `i₁` is less than `iₙ`. =#
         if num_placed == 0
-            filter!(((lpo, _),) -> lpo[search_depth] > candidate, perimeter_new)
+            filter!(((lpo, _),) -> candidate < lpo[end], perimeter_new)
         end
+
+        if num_placed >= n - search_depth
+            #= We are already filling up the last `search_depth` positions, so we restrict
+            the search to LPOs in which `candidate` is placed at the next position. =#
+            rel = ==
+        else
+            #= We are still filling up the first `n - search_depth` positions, so we allow
+            all LPOs that are compatible with `candidate` being placed anywhere at or before
+            the next position. =#
+            rel = <=
+        end
+
+        filter!(
+            ((_, time_stamp),) -> rel(time_stamp[candidate], num_placed + 1), perimeter_new
+        )
     end
 
     return perimeter_new
@@ -251,24 +427,4 @@ function _dcm_is_compatible(
     constraints = (1:l) .+ num_placed
 
     return all(latest_positions .>= constraints)
-end
-
-function _lpo_time_stamps(lpo::Vector{Int}, A::AbstractMatrix{Bool}, k::Int)
-    n = size(A, 1)
-
-    time_stamps = zeros(Int, n)
-    d = length(lpo)
-    foreach(((i, node),) -> time_stamps[node] = n - d + i, enumerate(lpo))
-
-    queue = Queue{Int}()
-    foreach(node -> enqueue!(queue, node), lpo)
-
-    while !isempty(queue)
-        node = dequeue!(queue)
-        unvisited = filter!(neighbor -> time_stamps[neighbor] == 0, findall(A[:, node]))
-        time_stamps[unvisited] .= time_stamps[node] - k
-        foreach(neighbor -> enqueue!(queue, neighbor), unvisited)
-    end
-
-    return time_stamps
 end

--- a/src/Recognition/deciders/del_corso_manzini.jl
+++ b/src/Recognition/deciders/del_corso_manzini.jl
@@ -40,15 +40,16 @@ Based on experimental results, the algorithm is feasible for ``n×n`` matrices u
 For readers of the original paper, what we call the Del Corso–Manzini recognition algorithm
 here is essentially a wrapper around the underlying `AddNode` subroutine in what
 [DCM99; p. 191](@cite) terms the "MB-ID algorithm" for bandwidth minimization (not mere
-recognition). MB-ID (which we also implement in [`Minimization.DelCorsoManzini`](@ref))
-calls this recognition procedure with incrementing values of ``k`` until a bandwidth-``k``
-ordering is found, with ``k`` initialized to some lower bound on the minimum bandwidth of
-``A`` up to symmetric permutation.
+recognition). MB-ID (which we also implement in
+[`MatrixBandwidth.Minimization.Exact.DelCorsoManzini`](@ref)) calls this recognition
+procedure with incrementing values of ``k`` until a bandwidth-``k`` ordering is found, with
+``k`` initialized to some lower bound on the minimum bandwidth of ``A`` up to symmetric
+permutation.
 
 [DCM99; p. 193](@cite) also describes an "MB-PS algorithm" for bandwidth minimization,
-which we implement in [`Minimization.DelCorsoManziniWithPS`](@ref). Similarly, the
-underlying recognition subroutine for MB-PS is implemented in
-[`Recognition.DelCorsoManziniWithPS`](@ref).
+which we implement in [`MatrixBandwidth.Minimization.Exact.DelCorsoManziniWithPS`](@ref).
+Similarly, the underlying recognition subroutine for MB-PS is implemented in
+[`DelCorsoManziniWithPS`](@ref).
 """
 struct DelCorsoManzini <: AbstractDecider end
 
@@ -113,14 +114,14 @@ For readers of the original paper, what we call the Del Corso–Manzini recognit
 with perimeter search here is essentially a wrapper around the underlying `AddNode1` and
 `Prune` subroutines in what [DCM99; p. 193](@cite) terms the "MB-PS algorithm" for bandwidth
 minimization (not mere recognition). MB-PS (which we also implement in
-[`Minimization.DelCorsoManziniWithPS`](@ref)) calls this recognition procedure with
-incrementing values of ``k`` until a bandwidth-``k`` ordering is found, with ``k``
-initialized to some lower bound on the minimum bandwidth of ``A`` up to symmetric
+[`MatrixBandwidth.Minimization.Exact.DelCorsoManziniWithPS`](@ref)) calls this recognition
+procedure with incrementing values of ``k`` until a bandwidth-``k`` ordering is found, with
+``k`` initialized to some lower bound on the minimum bandwidth of ``A`` up to symmetric
 permutation.
 
 [DCM99; p. 191](@cite) also describes an "MB-ID algorithm" for bandwidth minimization, which
-we implement in [`Minimization.DelCorsoManzini`](@ref). Similarly, the underlying
-recognition subroutine for MB-ID is implemented in [`Recognition.DelCorsoManzini`](@ref).
+we implement in [`MatrixBandwidth.Minimization.Exact.DelCorsoManzini`](@ref). Similarly, the
+underlying recognition subroutine for MB-ID is implemented in [`DelCorsoManzini`](@ref).
 """
 struct DelCorsoManziniWithPS{D<:Union{Nothing,Int}} <: AbstractDecider
     depth::D

--- a/src/core.jl
+++ b/src/core.jl
@@ -101,10 +101,11 @@ end
 """
     bandwidth_lower_bound(A) -> Int
 
-Compute a lower bound on the bandwidth of `A` using [CSG05](@cite)'s results.
+Compute a lower bound on the bandwidth of `A` using [CSG05; pp.359--60](@cite)'s results.
 
-The nonzero support of `A` is assumed to be symmetric, since [CSG05](@cite)'s bound was
-discovered in the context of undirected graphs (whose adjacency matrices are symmetric).
+`A` is assumed to be structurally symmetric, since the bound from
+[CSG05; pp.359--60](@cite) was discovered in the context of undirected graphs (whose
+adjacency matrices are symmetric).
 
 The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
 ``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
@@ -114,17 +115,19 @@ nonzero entry in the ``k``-th superdiagonal or subdiagonal.
 
 In contrast to [`minimize_bandwidth`](@ref), this function does not attempt to truly
 minimize the bandwidth of `A`—it simply returns a lower bound on its bandwidth up to
-symmetric permutation of its rows and columns. This bound is not tight, but it is easily
-computable in ``O(n³)`` time, dominated by the Floyd–Warshall algorithm call. (The core
-logic here runs in ``O(n²)`` time.)
+symmetric permutation of its rows and columns. This bound is not generally tight, but it
+indeed matches the true minimum in many non-trivial cases and is easily computable in
+``O(n³)`` time (dominated by the Floyd–Warshall algorithm call; the core logic itself runs
+in ``O(n²)`` time).
 
 # Arguments
 - `A::AbstractMatrix{<:Number}`: the (square) matrix on whose bandwidth a lower bound is to
-    be computed. `A` must have a symmetric nonzero support (i.e., `A[i, j]` is nonzero if
-    and only if `A[j, i]` is nonzero).
+    be computed. `A` must be structurally symmetric (i.e., `A[i, j]` must be nonzero if
+    and only if `A[j, i]` is nonzero for ``1 ≤ i, j ≤ n``).
 
 # Returns
-- `::Int`: a lower bound on the bandwidth of `A`. (This bound is not tight.)
+- `::Int`: a lower bound on the bandwidth of `A`. (This bound is tight in many non-trivial
+    cases but not universally so.)
 
 # Examples
 The function correctly computes a bound less than (or equal to) the true minimum bandwidth

--- a/test/Minimization/Exact/Exact.jl
+++ b/test/Minimization/Exact/Exact.jl
@@ -11,8 +11,16 @@ Test suite for the `Minimization.Exact` submodule of the `MatrixBandwidth.jl` pa
 """
 module TestExact
 
-include("solvers/caprara_salazar_gonzalez.jl")
-include("solvers/del_corso_manzini.jl")
-include("solvers/saxe_gurari_sudborough.jl")
+const TEST_GROUPS = [
+    "solvers/caprara_salazar_gonzalez",
+    "solvers/del_corso_manzini",
+    "solvers/saxe_gurari_sudborough",
+]
+
+for group in TEST_GROUPS
+    @info "Testing `Minimization/Exact/$group`"
+    include("$group.jl")
+    println()
+end
 
 end

--- a/test/Minimization/Heuristic/Heuristic.jl
+++ b/test/Minimization/Heuristic/Heuristic.jl
@@ -11,7 +11,12 @@ Test suite for the `Minimization.Heuristic` submodule of the `MatrixBandwidth.jl
 """
 module TestHeuristic
 
-include("solvers/gibbs_poole_stockmeyer.jl")
-include("solvers/cuthill_mckee.jl")
+const TEST_GROUPS = ["solvers/gibbs_poole_stockmeyer", "solvers/cuthill_mckee"]
+
+for group in TEST_GROUPS
+    @info "Testing `Minimization/Heuristic/$group`"
+    include("$group.jl")
+    println()
+end
 
 end

--- a/test/Minimization/Metaheuristic/Metaheuristic.jl
+++ b/test/Minimization/Metaheuristic/Metaheuristic.jl
@@ -12,8 +12,14 @@ package.
 """
 module TestMetaheuristic
 
-include("solvers/grasp.jl")
-include("solvers/simulated_annealing.jl")
-include("solvers/genetic_algorithm.jl")
+const TEST_GROUPS = [
+    "solvers/grasp", "solvers/simulated_annealing", "solvers/genetic_algorithm"
+]
+
+for group in TEST_GROUPS
+    @info "Testing `Minimization/Metaheuristic/$group`"
+    include("$group.jl")
+    println()
+end
 
 end

--- a/test/Minimization/Minimization.jl
+++ b/test/Minimization/Minimization.jl
@@ -11,10 +11,19 @@ Test suite for the `Minimization` submodule of the `MatrixBandwidth.jl` package.
 """
 module TestMinimization
 
-include("core.jl")
+const TEST_GROUPS = ["core"]
+const NESTED_TEST_SUITES = [
+    "Exact/Exact.jl", "Heuristic/Heuristic.jl", "Metaheuristic/Metaheuristic.jl"
+]
 
-include("Exact/Exact.jl")
-include("Heuristic/Heuristic.jl")
-include("Metaheuristic/Metaheuristic.jl")
+for group in TEST_GROUPS
+    @info "Testing `Minimization/$group`"
+    include("$group.jl")
+    println()
+end
+
+for suite in NESTED_TEST_SUITES
+    include(suite)
+end
 
 end

--- a/test/Recognition/Recognition.jl
+++ b/test/Recognition/Recognition.jl
@@ -11,10 +11,17 @@ Test suite for the `Recognition` submodule of the `MatrixBandwidth.jl` package.
 """
 module TestRecognition
 
-include("core.jl")
+const TEST_GROUPS = [
+    "core",
+    "deciders/caprara_salazar_gonzalez",
+    "deciders/del_corso_manzini",
+    "deciders/saxe_gurari_sudborough",
+]
 
-include("deciders/caprara_salazar_gonzalez.jl")
-include("deciders/del_corso_manzini.jl")
-include("deciders/saxe_gurari_sudborough.jl")
+for group in TEST_GROUPS
+    @info "Testing `Recognition/$group`"
+    include("$group.jl")
+    println()
+end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,27 +7,33 @@
 using MatrixBandwidth
 using Test
 
+const STATIC_ANALYZERS = ["Aqua", "JET"]
+const TEST_GROUPS = ["core", "utils"]
+const NESTED_TEST_SUITES = ["Minimization/Minimization.jl", "Recognition/Recognition.jl"]
+
 # Run static analysis
-for analyzer in readlines(joinpath(@__DIR__, "staticanalyzers"))
-    if !isempty(analyzer)
-        @info "Running static analysis with $analyzer.jl"
-        include("$analyzer.jl")
-        println()
-    end
+for analyzer in STATIC_ANALYZERS
+    @info "Running static analysis with $analyzer"
+    include(joinpath("static_analysis/", "$(lowercase(analyzer)).jl"))
+    println()
 end
 
 # Run unit tests
-for group in readlines(joinpath(@__DIR__, "testgroups"))
-    if !isempty(group)
-        @info "Testing `$group`"
-        include("$group.jl")
-        println()
-    end
+for group in TEST_GROUPS
+    @info "Testing `$group`"
+    include("$group.jl")
+    println()
 end
 
-# Check that all public names in the package are documented
+# Run more unit tests
+for suite in NESTED_TEST_SUITES
+    include(suite)
+end
+
+# Check that all public names in the package have docstrings
 @testset "Docstrings" begin
-    if VERSION >= v"1.11" # `Docs.undocumented_names` was introduced in Julia 1.11
+    if VERSION >= v"1.11" # `Docs.undocumented_names` was only introduced in Julia 1.11
+        @info "Checking for undocumented names"
         @test isempty(Docs.undocumented_names(MatrixBandwidth))
     else
         @info "Skipping `Docs.undocumented_names` test: not available on Julia $(VERSION)"

--- a/test/staticanalyzers
+++ b/test/staticanalyzers
@@ -1,2 +1,0 @@
-static_analysis/aqua
-static_analysis/jet

--- a/test/testgroups
+++ b/test/testgroups
@@ -1,5 +1,0 @@
-core
-utils
-
-Minimization/Minimization
-Recognition/Recognition


### PR DESCRIPTION
This PR adds docstrings to the completed Del Corso&ndash;Manzini algorithms (both algorithms, in both Minimization and Recognition) as well as to the Caprara&ndash;Salazar-Gonz&aacute;lez algorithm. Complexity analysis is performed for DCM but not yet for CSG. Examples are forthcoming for both.

It also identifies some room for optimization in the DCM with PS algorithm and notes an error in the original paper (to explain the mismatch between implementation and source).

Finally, it also fixes #41, making sure that proper info is printed for each test group while running unit tests.

(A slight change is also made to the Cuthill&ndash;McKee and reverse Cuthill&ndash;McKee documentation to stay consistent with the new DCM/CSG docstrings, but it is very minor.)