### PR TITLE
Add brute force algos; incorp. into tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The following algorithms are currently supported:
     - Del Corso&ndash;Manzini algorithm
     - Del Corso&ndash;Manzini algorithm with perimeter search
     - Saxe&ndash;Gurari&ndash;Sudborough algorithm
+    - Brute-force search
   - *Heuristic*
     - Gibbs&ndash;Poole&ndash;Stockmeyer algorithm
     - Cuthill&ndash;McKee algorithm
@@ -70,6 +71,7 @@ The following algorithms are currently supported:
   - Del Corso&ndash;Manzini algorithm
   - Del Corso&ndash;Manzini algorithm with perimeter search
   - Saxe&ndash;Gurari&ndash;Sudborough algorithm
+  - Brute-force search
 
 (As we remain in the early stages of development, some of these may not yet be fully implemented and/or tested.)
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -61,6 +61,7 @@ The following algorithms are currently supported:
     - Del Corso–Manzini algorithm
     - Del Corso–Manzini algorithm with perimeter search
     - Saxe–Gurari–Sudborough algorithm
+    - Brute-force search
   - *Heuristic*
     - Gibbs–Poole–Stockmeyer algorithm
     - Cuthill–McKee algorithm
@@ -74,6 +75,7 @@ The following algorithms are currently supported:
   - Del Corso–Manzini algorithm
   - Del Corso–Manzini algorithm with perimeter search
   - Saxe–Gurari–Sudborough algorithm
+  - Brute-force search
 
 (As we remain in the early stages of development, some of these may not yet be fully implemented and/or tested.)
 

--- a/src/MatrixBandwidth.jl
+++ b/src/MatrixBandwidth.jl
@@ -34,8 +34,9 @@ The following algorithms are currently supported:
         - Caprara–Salazar-González algorithm ([`Minimization.CapraraSalazarGonzalez`](@ref))
         - Del Corso–Manzini algorithm ([`Minimization.DelCorsoManzini`](@ref))
         - Del Corso–Manzini algorithm with perimeter search
-          ([`Minimization.DelCorsoManziniWithPS`](@ref))
+            ([`Minimization.DelCorsoManziniWithPS`](@ref))
         - Saxe–Gurari–Sudborough algorithm ([`Minimization.SaxeGurariSudborough`](@ref))
+        - Brute-force search ([`Minimization.BruteForce`](@ref))
     - *Heuristic*
         - Gibbs–Poole–Stockmeyer algorithm ([`Minimization.GibbsPooleStockmeyer`](@ref))
         - Cuthill–McKee algorithm ([`Minimization.CuthillMcKee`](@ref))
@@ -46,10 +47,11 @@ The following algorithms are currently supported:
         - Genetic algorithm ([`Minimization.GeneticAlgorithm`](@ref))
 - **Recognition**
     - Caprara–Salazar-González algorithm ([`Recognition.CapraraSalazarGonzalez`](@ref))
-    - Del Corso–Manzini algorith ([`Recognition.DelCorsoManzini`](@ref))
+    - Del Corso–Manzini algorithm ([`Recognition.DelCorsoManzini`](@ref))
     - Del Corso–Manzini algorithm with perimeter search
-      ([`Recognition.DelCorsoManziniWithPS`](@ref))
+        ([`Recognition.DelCorsoManziniWithPS`](@ref))
     - Saxe–Gurari–Sudborough algorithm ([`Recognition.SaxeGurariSudborough`](@ref))
+    - Brute-force search ([`Recognition.BruteForce`](@ref))
 
 [Full documentation](https://Luis-Varona.github.io/MatrixBandwidth.jl/dev/) is available for
 the latest development version of this package.

--- a/src/Minimization/Exact/Exact.jl
+++ b/src/Minimization/Exact/Exact.jl
@@ -21,6 +21,7 @@ The following exact algorithms are currently supported:
 - Del Corso–Manzini algorithm ([`DelCorsoManzini`](@ref))
 - Del Corso–Manzini algorithm with perimeter search ([`DelCorsoManziniWithPS`](@ref))
 - Saxe–Gurari–Sudborough algorithm ([`SaxeGurariSudborough`](@ref))
+- Brute-force search ([`BruteForce`](@ref))
 
 This submodule is part of the `MatrixBandwidth.Minimization` submodule of the
 [MatrixBandwidth.jl](https://github.com/Luis-Varona/MatrixBandwidth.jl) package.
@@ -31,14 +32,15 @@ module Exact
 import ..Recognition
 import ..AbstractSolver
 import ..NotImplementedError, ..StructuralAsymmetryError
-import ..bandwidth_lower_bound
+import ..bandwidth, ..bandwidth_lower_bound
 import .._requires_symmetry
 import .._approach, .._bool_minimal_band_ordering
 #! format: on
 
 using Combinatorics
 
-export CapraraSalazarGonzalez, DelCorsoManzini, DelCorsoManziniWithPS, SaxeGurariSudborough
+export CapraraSalazarGonzalez,
+    DelCorsoManzini, DelCorsoManziniWithPS, SaxeGurariSudborough, BruteForce
 
 include("types.jl")
 
@@ -46,5 +48,6 @@ include("solvers/caprara_salazar_gonzalez.jl")
 # Defines both `DelCorsoManzini` and `DelCorsoManziniWithPS`
 include("solvers/del_corso_manzini.jl")
 include("solvers/saxe_gurari_sudborough.jl")
+include("solvers/brute_force.jl")
 
 end

--- a/src/Minimization/Exact/solvers/brute_force.jl
+++ b/src/Minimization/Exact/solvers/brute_force.jl
@@ -1,0 +1,45 @@
+# Copyright 2025 Luis M. B. Varona
+#
+# Licensed under the MIT license <LICENSE or
+# http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
+# distributed except according to those terms.
+
+"""
+    BruteForce <: ExactSolver <: AbstractSolver <: AbstractAlgorithm
+
+The simplest exact method for minimizing the bandwidth of a matrix is to iterate over all
+possible symmetric permutations and compare the bandwidths they induce.
+
+Since ``i₁, i₂, … iₙ`` induces the same bandwidth as ``iₙ, iₙ₋₁, … i₁``, we restrict our
+search to orderings such that ``i₁ ≤ iₙ`` (with equality checked just in case ``n = 1``).
+
+# Performance
+Given an ``n×n`` input matrix ``A``, this brute-force algorithm runs in ``O(n! ⋅ n²)`` time:
+- Precisely ``n!/2`` permutations are checked (except when ``n = 1``, in which case
+    ``1! = 1`` permutation is checked). This is, clearly, ``O(n!)``.
+- For each permutation, the [`bandwidth`](@ref) function is called on ``A[perm, perm]``,
+    which takes ``O(n²)`` time.
+- Therefore, the overall time complexity is ``O(n! ⋅ n²)``.
+
+# Examples
+[TODO: Write here]
+
+# Notes
+Brute force is by far the slowest approach to matrix bandwidth minimization and should only
+be used in very niche cases like writing unit tests for other non-naïve algorithms.
+"""
+struct BruteForce <: ExactSolver end
+
+Base.summary(::BruteForce) = "Brute-force search"
+
+_requires_symmetry(::BruteForce) = false
+
+function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::BruteForce)
+    #= `i₁, i₂, … iₙ` induces the same bandwidth as `iₙ, iₙ₋₁, … i₁`, so without loss of
+    generality, we restrict our search to orderings such that `i₁ ≤ iₙ` (with equality
+    checked just in case `n = 1`). =#
+    orderings_up_to_reversal = Iterators.filter(
+        perm -> perm[1] <= perm[end], permutations(axes(A, 1))
+    )
+    return argmin(perm -> bandwidth(A[perm, perm]), orderings_up_to_reversal)
+end

--- a/src/Minimization/Exact/solvers/del_corso_manzini.jl
+++ b/src/Minimization/Exact/solvers/del_corso_manzini.jl
@@ -29,15 +29,15 @@ is, ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is nonzero for ``1 �
 
 # Performance
 Given an ``n×n`` input matrix ``A``, the Del Corso–Manzini algorithm runs in
-``O(n³ ⋅ n!)`` time:
+``O(n! ⋅ n³)`` time:
 - For each underlying "bandwidth ≤ ``k``" check, we perform a depth-first search of
     ``O(n!)`` partial orderings.
 - Checking plausibility of each partial ordering takes ``O(nk)`` time, resulting in
-    ``O(nk ⋅ n!)`` steps for each value of ``k``.
+    ``O(n! ⋅ nk)`` steps for each value of ``k``.
 - The difference between the maximum possible bandwidth (``n - 1``) and our initial lower
-    bound grows linearly in ``n``, so we run the underlying ``O(nk ⋅ n!)`` recognition
+    bound grows linearly in ``n``, so we run the underlying ``O(n! ⋅ nk)`` recognition
     algorithm ``O(n)`` times.
-- Finally, ``∑ₖ₌₀ⁿ⁻¹ nk = O(n³)``, so the overall time complexity is ``O(n³ ⋅ n!)``.
+- Finally, ``∑ₖ₌₀ⁿ⁻¹ nk = O(n³)``, so the overall time complexity is ``O(n! ⋅ n³)``.
 
 Of course, this is but an upper bound on the time complexity of Del Corso–Manzini, achieved
 only in the most pathological of cases. In practice, efficient pruning techniques and
@@ -105,17 +105,17 @@ nonzero for ``1 ≤ i, j ≤ n``).
 
 # Performance
 Given an ``n×n`` input matrix ``A`` and perimeter search depth ``d``, the Del Corso–Manzini
-algorithm with perimeter search runs in ``O(nᴰ⁺¹ ⋅ n!)`` time, where ``Dᴰ = max(d, 2)``:
+algorithm with perimeter search runs in ``O(n! ⋅ nᴰ⁺¹)`` time, where ``Dᴰ = max(d, 2)``:
 - For each underlying "bandwidth ≤ ``k``" check, we perform a depth-first search of
     ``O(n!)`` partial orderings.
 - Checking plausibility of each partial ordering takes ``O(nk)`` time, and checking
     compatibility with all size-``d`` LPOs takes ``O(nᵈ)`` time. Thus, the overall time
-    complexity for each value of ``k`` is ``O((nᵈ + nk) ⋅ n!)``.
+    complexity for each value of ``k`` is ``O(n! ⋅ (nᵈ + nk))``.
 - The difference between the maximum possible bandwidth (``n - 1``) and our initial lower
-    bound grows linearly in ``n``, so we run the underlying ``O((nᵈ + nk) ⋅ n!)``
+    bound grows linearly in ``n``, so we run the underlying ``O(n! ⋅ (nᵈ + nk))``
     recognition algorithm ``O(n)`` times.
 - Finally, ``∑ₖ₌₀ⁿ⁻¹ (nᵈ + nk) = O(nᵈ⁺¹ + n³)``, so the overall time complexity
-    is ``O(nᴰ⁺¹ ⋅ n!)``, where ``D = max(d, 2)``.
+    is ``O(n! ⋅ nᴰ⁺¹)``, where ``D = max(d, 2)``.
 
 Of course, this is but an upper bound on the time complexity of Del Corso–Manzini with
 perimeter search, achieved only in the most pathological of cases. In practice, efficient
@@ -199,6 +199,11 @@ function _bool_minimal_band_ordering(
     A::AbstractMatrix{Bool}, solver::DelCorsoManziniWithPS{Int}
 )
     n = size(A, 1)
+    ps_depth = solver.depth
+
+    if ps_depth > n
+        throw(ArgumentError("Perimeter search depth $ps_depth exceeds matrix order $n"))
+    end
 
     ordering_buf = Vector{Int}(undef, n)
     k = bandwidth_lower_bound(A)
@@ -207,7 +212,6 @@ function _bool_minimal_band_ordering(
     unselected = Set(1:n)
     adj_list = Set{Int}()
     num_placed = 0
-    ps_depth = solver.depth
     lpos = Iterators.flatmap(permutations, combinations(1:n, ps_depth))
 
     ordering = nothing

--- a/src/Minimization/Minimization.jl
+++ b/src/Minimization/Minimization.jl
@@ -28,6 +28,7 @@ The following algorithms are currently supported:
     - Del Corso–Manzini algorithm ([`DelCorsoManzini`](@ref))
     - Del Corso–Manzini algorithm with perimeter search ([`DelCorsoManziniWithPS`](@ref))
     - Saxe–Gurari–Sudborough algorithm ([`SaxeGurariSudborough`](@ref))
+    - Brute-force search ([`BruteForce`](@ref))
 - *Heuristic*
     - Gibbs–Poole–Stockmeyer algorithm ([`GibbsPooleStockmeyer`](@ref))
     - Cuthill–McKee algorithm ([`CuthillMcKee`](@ref))
@@ -65,7 +66,8 @@ export MinimizationResult, minimize_bandwidth
 export CapraraSalazarGonzalez, # Exact solvers
     DelCorsoManzini,
     DelCorsoManziniWithPS,
-    SaxeGurariSudborough
+    SaxeGurariSudborough,
+    BruteForce
 export GibbsPooleStockmeyer, CuthillMcKee, ReverseCuthillMcKee # Heuristic solvers
 export SimulatedAnnealing, GeneticAlgorithm, GRASP # Metaheuristic solvers
 

--- a/src/Recognition/Recognition.jl
+++ b/src/Recognition/Recognition.jl
@@ -26,6 +26,7 @@ The following algorithms are currently supported:
 - Del Corso–Manzini algorithm ([`DelCorsoManzini`](@ref))
 - Del Corso–Manzini algorithm with perimeter search ([`DelCorsoManziniWithPS`](@ref))
 - Saxe–Gurari–Sudborough algorithm ([`SaxeGurariSudborough`](@ref))
+- Brute-force search ([`BruteForce`](@ref))
 
 This submodule is part of the
 [MatrixBandwidth.jl](https://github.com/Luis-Varona/MatrixBandwidth.jl) package.
@@ -43,6 +44,14 @@ import .._is_structurally_symmetric, .._offdiag_nonzero_support
 using Combinatorics: combinations, permutations
 using DataStructures: Queue, enqueue!, dequeue!
 
+# THe output struct and core recognition function
+export RecognitionResult, has_bandwidth_k_ordering
+export CapraraSalazarGonzalez, # Recognition algorithms
+    DelCorsoManzini,
+    DelCorsoManziniWithPS,
+    SaxeGurariSudborough,
+    BruteForce
+
 include("types.jl")
 include("core.jl")
 
@@ -50,13 +59,7 @@ include("deciders/caprara_salazar_gonzalez.jl")
 # Defines both `DelCorsoManzini` and `DelCorsoManziniWithPS`
 include("deciders/del_corso_manzini.jl")
 include("deciders/saxe_gurari_sudborough.jl")
-
-# THe output struct and core recognition function
-export RecognitionResult, has_bandwidth_k_ordering
-export CapraraSalazarGonzalez, # Recognition algorithms
-    DelCorsoManzini,
-    DelCorsoManziniWithPS,
-    SaxeGurariSudborough
+include("deciders/brute_force.jl")
 
 const DEFAULT_DECIDER = CapraraSalazarGonzalez()
 

--- a/src/Recognition/deciders/brute_force.jl
+++ b/src/Recognition/deciders/brute_force.jl
@@ -1,0 +1,62 @@
+# Copyright 2025 Luis M. B. Varona
+#
+# Licensed under the MIT license <LICENSE or
+# http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
+# distributed except according to those terms.
+
+"""
+    BruteForce <: AbstractDecider <: AbstractAlgorithm
+
+The simplest method for determining, given some fixed ``k ∈ ℕ``, whether a matrix has
+bandwidth at most ``k`` up to symmetric permutation is to iterate over all orderings and
+compute the bandwidth induced by each.
+
+Since ``i₁, i₂, … iₙ`` induces the same bandwidth as ``iₙ, iₙ₋₁, … i₁``, we restrict our
+search to orderings such that ``i₁ ≤ iₙ`` (with equality checked just in case ``n = 1``).
+
+If a bandwidth-``k`` ordering is found, the algorithm breaks early instead of continuing
+to check subsequent permutations.
+
+# Performance
+Given an ``n×n`` input matrix ``A``, this brute-force algorithm runs in ``O(n! ⋅ n²)`` time:
+- Up to ``n!/2`` permutations may be checked (except when ``n = 1``, in which case
+    ``1! = 1`` permutation is checked). This is, clearly, ``O(n!)``.
+- For each permutation, the [`bandwidth`](@ref) function is called on ``A[perm, perm]``,
+    which takes ``O(n²)`` time.
+- Therefore, the overall time complexity is ``O(n! ⋅ n²)``.
+
+# Examples
+[TODO: Write here]
+
+# Notes
+Brute force is by far the slowest approach to matrix bandwidth recognition and should only
+be used in very niche cases like writing unit tests for other non-naïve algorithms.
+"""
+struct BruteForce <: AbstractDecider end
+
+Base.summary(::BruteForce) = "Brute-force search"
+
+_requires_symmetry(::BruteForce) = false
+
+#= We take advantage of the laziness of `permutations` and `Iterators.filter` to avoid
+iterating over all orderings if a valid one is found early. =#
+function _bool_bandwidth_k_ordering(A::AbstractMatrix{Bool}, k::Int, ::BruteForce)
+    #= `i₁, i₂, … iₙ` induces the same bandwidth as `iₙ, iₙ₋₁, … i₁`, so without loss of
+    generality, we restrict our search to orderings such that `i₁ ≤ iₙ` (with equality
+    checked just in case `n = 1`). =#
+    orderings_up_to_reversal = Iterators.filter(
+        perm -> perm[1] <= perm[end], permutations(axes(A, 1))
+    )
+    valid_orderings = Iterators.filter(
+        perm -> bandwidth(A[perm, perm]) <= k, orderings_up_to_reversal
+    )
+    res = iterate(valid_orderings)
+
+    if isnothing(res)
+        ordering = nothing
+    else
+        ordering = res[1]
+    end
+
+    return ordering
+end

--- a/src/Recognition/types.jl
+++ b/src/Recognition/types.jl
@@ -32,13 +32,13 @@ Output struct for matrix bandwidth recognition results.
 - `ordering::O<:Union{Nothing,Vector{Int}}`: an ordering of the rows and columns of `matrix`
     inducing a bandwidth at most `k`, if such an ordering exists; otherwise, `nothing`.
 - `k::Int`: the threshold bandwidth against which to test.
-- `has_bandwidth_k_ordering::Bool`: whether the matrix has an ordering inducing a bandwidth
-    at most `k`. (This is `true` if and only if `ordering` is not `nothing`.)
+- `has_ordering::Bool`: whether the matrix has an ordering inducing a bandwidth at most `k`.
+    (This is `true` if and only if `ordering` is not `nothing`.)
 
 # Constructors
 - `RecognitionResult(decider, matrix, ordering, k)`: constructs a new `RecognitionResult`
-    instance with the given fields. The `has_bandwidth_k_ordering` field is automatically
-    determined based on whether `ordering` is `nothing` or a `Vector{Int}`.
+    instance with the given fields. The `has_ordering` field is automatically determined
+    based on whether `ordering` is `nothing` or a `Vector{Int}`.
 """
 struct RecognitionResult{
     A<:AbstractDecider,M<:AbstractMatrix{<:Number},O<:Union{Nothing,Vector{Int}}
@@ -47,7 +47,7 @@ struct RecognitionResult{
     matrix::M
     ordering::O
     k::Int
-    has_bandwidth_k_ordering::Bool
+    has_ordering::Bool
 
     function RecognitionResult(
         algorithm::A, matrix::M, ::Nothing, k::Int
@@ -69,7 +69,7 @@ function Base.show(io::IO, res::RecognitionResult)
     println(io, "Results of Bandwidth Recognition Algorithm")
     println(io, " * Algorithm: $(summary(res.algorithm))")
     println(io, " * k: $(res.k)")
-    println(io, " * Has Bandwidth ≤ k Ordering: $(res.has_bandwidth_k_ordering)")
+    println(io, " * Has Bandwidth ≤ k Ordering: $(res.has_ordering)")
     println(io, " * Original Bandwidth: $(bandwidth(res.matrix))")
     print(io, " * Matrix Size: $n×$n")
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -143,7 +143,7 @@ julia> A = sprand(n, n, p);
 
 julia> A = A + A'; # Make `A` structurally symmetric
 
-julia> minimum(Iterators.map(perm -> bandwidth(A[perm, perm]), permutations(1:n)))
+julia> minimize_bandwidth(A, Minimization.BruteForce()).bandwidth # Foolproof algorithm
 5
 
 julia> bandwidth_lower_bound(A) # Always less than or equal to the true minimum bandwidth

--- a/test/Minimization/Exact/solvers/del_corso_manzini.jl
+++ b/test/Minimization/Exact/solvers/del_corso_manzini.jl
@@ -14,8 +14,59 @@ module TestDelCorsoManzini
 
 using MatrixBandwidth
 using MatrixBandwidth.Minimization
+using SparseArrays
 using Test
 
-# TODO: Write here
+const MAX_ORDER = 7
+const NUM_ITER = 100
+
+@testset "DCM – Brute force verification (n ≤ $MAX_ORDER)" begin
+    for n in 1:MAX_ORDER, _ in 1:NUM_ITER
+        density = rand()
+        A = sprand(n, n, density)
+        A = A + A' # Make `A` structurally symmetric
+
+        res_bf = minimize_bandwidth(A, BruteForce())
+        res_dcm = minimize_bandwidth(A, DelCorsoManzini())
+        ordering_dcm = res_dcm.ordering
+
+        @test res_bf.bandwidth ==
+            res_dcm.bandwidth ==
+            bandwidth(A[ordering_dcm, ordering_dcm])
+    end
+end
+
+@testset "DCM-PS (default depth) – Brute force verification (n ≤ $MAX_ORDER)" begin
+    for n in 1:MAX_ORDER, _ in 1:NUM_ITER
+        density = rand()
+        A = sprand(n, n, density)
+        A = A + A' # Make `A` structurally symmetric
+
+        res_bf = minimize_bandwidth(A, BruteForce())
+        res_dcm = minimize_bandwidth(A, DelCorsoManziniWithPS())
+        ordering_dcm = res_dcm.ordering
+
+        @test res_bf.bandwidth ==
+            res_dcm.bandwidth ==
+            bandwidth(A[ordering_dcm, ordering_dcm])
+    end
+end
+
+@testset "DCM-PS (custom depth) – Brute force verification (n ≤ $MAX_ORDER)" begin
+    for n in 1:MAX_ORDER, _ in 1:NUM_ITER
+        density = rand()
+        A = sprand(n, n, density)
+        A = A + A' # Make `A` structurally symmetric
+        depth = rand(1:n)
+
+        res_bf = minimize_bandwidth(A, BruteForce())
+        res_dcm = minimize_bandwidth(A, DelCorsoManziniWithPS(depth))
+        ordering_dcm = res_dcm.ordering
+
+        @test res_bf.bandwidth ==
+            res_dcm.bandwidth ==
+            bandwidth(A[ordering_dcm, ordering_dcm])
+    end
+end
 
 end

--- a/test/Minimization/Heuristic/solvers/cuthill_mckee.jl
+++ b/test/Minimization/Heuristic/solvers/cuthill_mckee.jl
@@ -4,6 +4,8 @@
 # http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
 # distributed except according to those terms.
 
+# TODO: I feel like this test suite is a bit messy. Let's rewrite it at some point.
+
 """
     TestCuthillMcKee
 
@@ -23,7 +25,7 @@ using Test
 const MAX_ORDER = 200
 const MAX_BAND = 10
 const MAX_DENSITY = 0.5
-const MAX_CCS = 8
+const MAX_CCS = 6
 
 include("../test_utils.jl")
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 MatrixBandwidth = "075aa41b-24fd-4573-b25f-92cae432c0f8"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -8,6 +9,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = ">=0.8.5, <1.0"
+Graphs = "1.10"
 JET = ">=0.8.26, <1.0"
 Random = "1.10"
 SparseArrays = "1.10"

--- a/test/Recognition/deciders/del_corso_manzini.jl
+++ b/test/Recognition/deciders/del_corso_manzini.jl
@@ -13,8 +13,129 @@ module TestDelCorsoManzini
 
 using MatrixBandwidth
 using MatrixBandwidth.Recognition
+using SparseArrays
 using Test
 
-# TODO: Write here
+const MAX_ORDER = 7
+const NUM_ITER = 100
+
+@testset "DCM – Bandwidth < k (n ≤ $MAX_ORDER)" begin
+    for n in 2:MAX_ORDER, i in 1:NUM_ITER
+        density = rand()
+        A = sprand(n, n, density)
+        A = A + A' # Make `A` structurally symmetric
+
+        while bandwidth(A) == 0
+            density = rand()
+            A = sprand(n, n, density)
+            A = A + A' # Make `A` structurally symmetric
+        end
+
+        b = minimize_bandwidth(A, Minimization.BruteForce()).bandwidth
+        k = rand(0:(b - 1))
+
+        res = has_bandwidth_k_ordering(A, k, DelCorsoManzini())
+
+        @test !res.has_ordering
+        @test isnothing(res.ordering)
+    end
+end
+
+@testset "DCM-PS (default depth) – Bandwidth < k (n ≤ $MAX_ORDER)" begin
+    for n in 2:MAX_ORDER, _ in 1:NUM_ITER
+        density = rand()
+        A = sprand(n, n, density)
+        A = A + A' # Make `A` structurally symmetric
+
+        while bandwidth(A) == 0
+            density = rand()
+            A = sprand(n, n, density)
+            A = A + A' # Make `A` structurally symmetric
+        end
+
+        b = minimize_bandwidth(A, Minimization.BruteForce()).bandwidth
+        k = rand(0:(b - 1))
+
+        res = has_bandwidth_k_ordering(A, k, DelCorsoManziniWithPS())
+
+        @test !res.has_ordering
+        @test isnothing(res.ordering)
+    end
+end
+
+@testset "DCM-PS (custom depth) – Bandwidth < k (n ≤ $MAX_ORDER)" begin
+    for n in 2:MAX_ORDER, _ in 1:NUM_ITER
+        density = rand()
+        A = sprand(n, n, density)
+        A = A + A' # Make `A` structurally symmetric
+
+        while bandwidth(A) == 0
+            density = rand()
+            A = sprand(n, n, density)
+            A = A + A' # Make `A` structurally symmetric
+        end
+
+        b = minimize_bandwidth(A, Minimization.BruteForce()).bandwidth
+        k = rand(0:(b - 1))
+        depth = rand(1:n)
+
+        res = has_bandwidth_k_ordering(A, k, DelCorsoManziniWithPS(depth))
+
+        @test !res.has_ordering
+        @test isnothing(res.ordering)
+    end
+end
+
+@testset "DCM – Bandwidth ≥ k (n ≤ $MAX_ORDER)" begin
+    for n in 1:MAX_ORDER, _ in 1:NUM_ITER
+        density = rand()
+        A = sprand(n, n, density)
+        A = A + A' # Make `A` structurally symmetric
+
+        b = minimize_bandwidth(A, Minimization.BruteForce()).bandwidth
+        k = rand(b:(n - 1))
+
+        res = has_bandwidth_k_ordering(A, k, DelCorsoManzini())
+        ordering = res.ordering
+
+        @test res.has_ordering
+        @test bandwidth(A[ordering, ordering]) <= k
+    end
+end
+
+@testset "DCM-PS (default depth) – Bandwidth ≥ k (n ≤ $MAX_ORDER)" begin
+    for n in 1:MAX_ORDER, _ in 1:NUM_ITER
+        density = rand()
+        A = sprand(n, n, density)
+        A = A + A' # Make `A` structurally symmetric
+
+        b = minimize_bandwidth(A, Minimization.BruteForce()).bandwidth
+        k = rand(b:(n - 1))
+
+        res = has_bandwidth_k_ordering(A, k, DelCorsoManziniWithPS())
+        ordering = res.ordering
+
+        @test res.has_ordering
+        @test bandwidth(A[ordering, ordering]) <= k
+    end
+end
+
+@testset "DCM-PS (custom depth) – Bandwidth ≥ k (n ≤ $MAX_ORDER)" begin
+    for n in 1:MAX_ORDER, _ in 1:NUM_ITER
+        density = rand()
+        A = sprand(n, n, density)
+        A = A + A' # Make `A` structurally symmetric
+
+        b = minimize_bandwidth(A, Minimization.BruteForce()).bandwidth
+        k = rand(b:(n - 1))
+        depth = rand(1:n)
+
+        res = has_bandwidth_k_ordering(A, k, DelCorsoManziniWithPS(depth))
+        ordering = res.ordering
+
+        @test res.has_ordering
+        @test bandwidth(A[ordering, ordering]) <= k
+    end
+end
 
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -12,8 +12,54 @@ Test suite for the core API of the `MatrixBandwidth.jl` package.
 module TestCore
 
 using MatrixBandwidth
+using MatrixBandwidth.Minimization
+using SparseArrays
+using Graphs
 using Test
 
-# TODO: Write here
+const MAX_ORDER1 = 100
+const NUM_ITER1 = 100
+
+const MAX_ORDER2 = 8
+const NUM_ITER2 = 10
+
+@testset "Testing `bandwidth` (n ≤ $MAX_ORDER1)" begin
+    for n in 1:MAX_ORDER1, _ in 1:NUM_ITER1
+        density = rand()
+        A = sprand(n, n, density)
+
+        k = bandwidth(A)
+
+        @test all(idx -> abs(idx[1] - idx[2]) <= k || A[idx] == 0, CartesianIndices(A))
+    end
+end
+
+@testset "Testing `bandwidth_lower_bound` (n ≤ $MAX_ORDER2)" begin
+    for n in 1:MAX_ORDER2, _ in 1:NUM_ITER2
+        density = rand()
+        A = sprand(n, n, density)
+        A = A + A' # Make `A` structurally symmetric
+
+        k = bandwidth_lower_bound(A)
+        res = minimize_bandwidth(A, BruteForce())
+
+        @test k <= res.bandwidth
+    end
+end
+
+@testset "Testing `_floyd_warshall_shortest_paths` (n ≤ $MAX_ORDER1)" begin
+    for n in 1:MAX_ORDER1, _ in 1:NUM_ITER1
+        density = rand()
+        A = sprand(Bool, n, n, density)
+        A = A .|| A' # Make `A` structurally symmetric
+        g = Graph(A)
+
+        res_matband = MatrixBandwidth._floyd_warshall_shortest_paths(A)
+        res_graphs = floyd_warshall_shortest_paths(g).dists
+        res_graphs = replace(res_graphs, typemax(Int) => Inf)
+
+        @test res_matband == res_graphs
+    end
+end
 
 end


### PR DESCRIPTION
We add both a solver and a decider for the brute-force approach to bandwidth minimization/recognition and use this to write effective tests for the DCM algorithms. We also tweak the CM/RCM tests slightly, reducing the number of iterations so they run in a more reasonable time frame.

Additionally, tests are created for the top-level core API of MatrixBandwidth as well.

Finally, a few typos/poor wordings are fixed throughout the document.

(Resolves #42.)