### PR TITLE
Add 'Basic use' and 'Documentation' sections in README

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -47,7 +47,7 @@ CurrentModule = MatrixBandwidth
 
 The *bandwidth* of an ``n \times n`` matrix ``A`` is the minimum non-negative integer ``k \in [0, n - 1]`` such that ``A_{i,j} = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth *at most* ``k`` if all entries above the ``k^\text{th}`` superdiagonal and below the ``k^\text{th}`` subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any nonzero entry in the ``k^\text{th}`` superdiagonal or subdiagonal.
 
-The *matrix bandwidth minimization problem* involves finding a permutation matrix ``P`` such that the bandwidth of ``PAP^\mathsf{T}`` is minimized; this is known to be NP-complete. Several heuristic algorithms (such as Gibbs–Poole–Stockmeyer) run in polynomial time while still producing near-optimal orderings in practice, but exact methods (like Caprara–Salazar-González) are exponential in time complexity and thus are only feasible for relatively small matrices.
+The *matrix bandwidth minimization problem* involves finding a permutation matrix ``P`` such that the bandwidth of ``PAP^\mathsf{T}`` is minimized; this is known to be NP-complete. Several heuristic algorithms (such as Gibbs–Poole–Stockmeyer) run in polynomial time while still producing near-optimal orderings in practice, but exact methods (like Caprara–Salazar-González) are at least exponential in time complexity and thus are only feasible for relatively small matrices.
 
 On the other hand, the *matrix bandwidth recognition problem* entails determining whether there exists a permutation matrix ``P`` such that the bandwidth of ``PAP^\mathsf{T}`` is at most some fixed non-negative integer ``k \in \mathbb{N}``—an optimal permutation that fully minimizes the bandwidth of ``A`` is not required. Unlike the NP-hard minimization problem, this is decidable in ``O(n^k)`` time.
 
@@ -91,6 +91,112 @@ When *MatrixBandwidth.jl* is finally added to the official Julia registry, you w
 
 ```julia-repl
 pkg> add MatrixBandwidth
+```
+
+## Basic use
+
+*MatrixBandwidth.jl* offers unified interfaces for both bandwidth minimization and bandwidth recognition via the `minimize_bandwidth` and `has_bandwidth_k_ordering` functions, respectively—the algorithm itself is specified as an argument. For example, to minimize the bandwidth of a random matrix with the reverse Cuthill–McKee algorithm, you can run the following code:
+
+```julia-repl
+julia> using SparseArrays
+
+julia> A = sprand(30, 30, 0.05); A = A + A' # Ensure structural symmetry
+30×30 SparseMatrixCSC{Float64, Int64} with 80 stored entries:
+⎡⢠⠖⠀⠀⠂⠀⠀⠐⢀⠀⠈⠀⠠⢀⠂⎤
+⎢⠀⠀⠀⢀⠠⠀⠀⠀⠠⠀⠢⠀⠀⡀⠀⎥
+⎢⠈⠀⠀⠂⡀⠈⠀⠘⠐⣌⠀⠀⠀⠀⠒⎥
+⎢⢀⠀⠀⠀⣀⠀⠀⢀⠁⠈⠀⡐⠀⠂⠀⎥
+⎢⠀⠐⠀⠂⡐⢤⡁⠀⠀⠀⢈⠀⠈⠀⠐⎥
+⎢⠂⠀⠈⠂⠀⠀⢀⠠⠂⠐⡕⠉⠁⠀⢀⎥
+⎢⠀⢂⠀⠠⠀⠀⠠⠀⠂⠀⠁⠀⠀⠄⠀⎥
+⎣⠈⠀⠀⠀⠘⠀⠀⠀⠐⠀⠀⠐⠀⠀⠀⎦
+
+julia> res = minimize_bandwidth(A, Minimization.ReverseCuthillMcKee())
+Results of Bandwidth Minimization Algorithm
+ * Algorithm: Reverse Cuthill–McKee
+ * Approach: heuristic
+ * Minimum Bandwidth: 8
+ * Original Bandwidth: 27
+ * Matrix Size: 30×30
+
+julia> A[res.ordering, res.ordering]
+30×30 SparseMatrixCSC{Float64, Int64} with 80 stored entries:
+⎡⠀⣤⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⎤
+⎢⠀⠈⠊⠀⠐⡆⠀⠀⠀⠀⠀⠀⠀⠀⠀⎥
+⎢⠀⠀⠰⠤⢀⠔⢈⠀⡢⡀⠀⠀⠀⠀⠀⎥
+⎢⠀⠀⠀⠀⠂⠐⠄⠅⡀⠀⢱⠀⠀⠀⠀⎥
+⎢⠀⠀⠀⠀⠈⠪⠀⠈⠄⠁⠀⢣⠀⠀⠀⎥
+⎢⠀⠀⠀⠀⠀⠀⠑⠒⠤⣀⡠⢎⠱⡀⠀⎥
+⎢⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠑⠢⢤⡳⡀⎥
+⎣⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠊⎦
+```
+
+Similarly, to determine whether a random matrix has bandwidth *at most* 10 (not necessarily caring about the true minimum) via the Del Corso–Manzini algorithm, you can run:
+
+```julia-repl
+julia> using SparseArrays
+
+julia> A = sprand(30, 30, 0.05); A = A + A' # Ensure structural symmetry
+30×30 SparseMatrixCSC{Float64, Int64} with 73 stored entries:
+⎡⠐⠀⢀⠀⣠⠄⠀⣀⠀⠂⠀⠀⠠⠄⠀⎤
+⎢⠀⠐⠀⠀⠀⠍⡐⠀⠓⠀⠀⠀⠀⠀⠀⎥
+⎢⠀⠞⡄⠄⠀⠀⠀⡀⠀⠂⡀⠂⠀⠀⠄⎥
+⎢⠀⢠⠐⠈⠀⠠⠀⠀⠈⠀⠀⠀⠀⡈⠁⎥
+⎢⠠⠀⠙⠀⠠⠀⠂⠀⠠⡢⠀⠀⡀⠈⠀⎥
+⎢⠀⠀⠀⠀⠠⠈⠀⠀⠀⠀⠁⠀⠈⢀⠀⎥
+⎢⠀⠆⠀⠀⠀⠀⡀⠠⡀⠈⠂⢀⠀⠀⠰⎥
+⎣⠀⠀⠀⠀⠀⠁⠁⠀⠀⠀⠀⠀⠐⠂⠁⎦
+
+julia> res = has_bandwidth_k_ordering(A, 10, Recognition.DelCorsoManzini())
+Results of Bandwidth Recognition Algorithm
+ * Algorithm: Del Corso–Manzini
+ * k: 10
+ * Has Bandwidth ≤ k Ordering: true
+ * Original Bandwidth: 24
+ * Matrix Size: 30×30
+
+julia> A[res.ordering, res.ordering]
+30×30 SparseMatrixCSC{Float64, Int64} with 73 stored entries:
+⎡⡀⠈⠈⠠⠑⡐⢄⠀⠀⠀⠀⠀⠀⠀⠀⎤
+⎢⠂⡀⠀⠀⠠⠀⠀⠓⠀⠀⠀⠀⠀⠀⠀⎥
+⎢⢑⠠⠀⠂⠠⠂⠀⠐⡉⠑⡀⠀⠀⠀⠀⎥
+⎢⠀⠑⢤⠀⢀⠀⠐⠀⠀⠈⠈⡑⢄⠀⠀⎥
+⎢⠀⠀⠀⠀⢇⠈⡀⠀⡐⠈⠀⠈⠂⠀⢀⎥
+⎢⠀⠀⠀⠀⠀⠈⢆⠠⡀⠀⡐⠈⠄⠀⠀⎥
+⎢⠀⠀⠀⠀⠀⠀⠀⠑⠈⠀⠀⠁⠄⠁⠀⎥
+⎣⠀⠀⠀⠀⠀⠀⠀⠀⠀⠐⠀⠀⠀⠀⠀⎦
+```
+
+## Documentation
+
+The full documentation is available at [GitHub Pages](https://luis-varona.github.io/MatrixBandwidth.jl/dev/). Documentation for methods and types is also available via the Julia REPL—for instance, to learn more about the `minimize_bandwidth` function, enter help mode by typing `?`, then run the following command:
+
+```julia-repl
+help?> minimize_bandwidth
+search: minimize_bandwidth MatrixBandwidth bandwidth
+
+  minimize_bandwidth(A, solver=GibbsPooleStockmeyer()) -> MinimizationResult
+
+  Minimize the bandwidth of A using the algorithm defined by solver.
+
+  The bandwidth of an n×n matrix A is the minimum non-negative integer k ∈ [0,
+  n - 1] such that A[i, j] = 0 whenever |i - j| > k. Equivalently, A has
+  bandwidth at most k if all entries above the kᵗʰ superdiagonal and below the
+  kᵗʰ subdiagonal are zero, and A has bandwidth at least k if there exists any
+  nonzero entry in the kᵗʰ superdiagonal or subdiagonal.
+
+  This function computes a (near-)optimal ordering π of the rows and columns
+  of A so that the bandwidth of PAPᵀ is minimized, where P is the permutation
+  matrix corresponding to π. This is known to be an NP-complete problem;
+  however, several heuristic algorithms such as Gibbs–Poole–Stockmeyer run in
+  polynomial time while still still producing near-optimal orderings in
+  practice. Exact methods like Caprara–Salazar-González are also available,
+  but they are at least exponential in time complexity and thus only feasible
+  for relatively small matrices.
+
+  Arguments
+  ≡≡≡≡≡≡≡≡≡
+  …
 ```
 
 ## Citing

--- a/src/MatrixBandwidth.jl
+++ b/src/MatrixBandwidth.jl
@@ -11,16 +11,16 @@ Fast algorithms for matrix bandwidth minimization and matrix bandwidth recogniti
 
 The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
 ``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
-has bandwidth *at most* ``k`` if all entries above the ``k``-th superdiagonal and below the
-``k``-th subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
-nonzero entry in the ``k``-th superdiagonal or subdiagonal.
+has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ superdiagonal and below the
+``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
+nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
 
 The *matrix bandwidth minimization problem* involves finding a permutation matrix ``P`` such
 that the bandwidth of ``PAPᵀ`` is minimized; this is known to be NP-complete. Several
 heuristic algorithms (such as Gibbs–Poole–Stockmeyer) run in polynomial time while still
 producing near-optimal orderings in practice, but exact methods (like
-Caprara–Salazar-González) are exponential in time complexity and thus are only feasible for
-relatively small matrices.
+Caprara–Salazar-González) are at least exponential in time complexity and thus are only
+feasible for relatively small matrices.
 
 On the other hand, the *matrix bandwidth recognition problem* entails determining whether
 there exists a permutation matrix ``P`` such that the bandwidth of ``PAPᵀ`` is at most some

--- a/src/Minimization/Minimization.jl
+++ b/src/Minimization/Minimization.jl
@@ -11,16 +11,16 @@ Exact, heuristic, and metaheuristic algorithms for matrix bandwidth minimization
 
 The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
 ``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
-has bandwidth *at most* ``k`` if all entries above the ``k``-th superdiagonal and below the
-``k``-th subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
-nonzero entry in the ``k``-th superdiagonal or subdiagonal.
+has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ superdiagonal and below the
+``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
+nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
 
 The *matrix bandwidth minimization problem* involves finding a permutation matrix ``P`` such
 that the bandwidth of ``PAPᵀ`` is minimized; this is known to be NP-complete. Several
 heuristic algorithms (such as Gibbs–Poole–Stockmeyer) run in polynomial time while still
 producing near-optimal orderings in practice, but exact methods (like
-Caprara–Salazar-González) are exponential in time complexity and thus are only feasible for
-relatively small matrices.
+Caprara–Salazar-González) are at least exponential in time complexity and thus are only
+feasible for relatively small matrices.
 
 The following algorithms are currently supported:
 - *Exact*

--- a/src/Minimization/core.jl
+++ b/src/Minimization/core.jl
@@ -11,16 +11,16 @@ Minimize the bandwidth of `A` using the algorithm defined by `solver`.
 
 The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
 ``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
-has bandwidth *at most* ``k`` if all entries above the ``k``-th superdiagonal and below the
-``k``-th subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
-nonzero entry in the ``k``-th superdiagonal or subdiagonal.
+has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ superdiagonal and below the
+``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
+nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
 
 This function computes a (near-)optimal ordering ``π`` of the rows and columns of ``A`` so
 that the bandwidth of ``PAPᵀ`` is minimized, where ``P`` is the permutation matrix
 corresponding to ``π``. This is known to be an NP-complete problem; however, several
-heuristic algorithms such as [`GibbsPooleStockmeyer`](@ref) run in polynomial time while
+heuristic algorithms such as Gibbs–Poole–Stockmeyer run in polynomial time while still
 still producing near-optimal orderings in practice. Exact methods like
-[`CapraraSalazarGonzalez`](@ref) are also available, but they are exponential in time
+Caprara–Salazar-González are also available, but they are at least exponential in time
 complexity and thus only feasible for relatively small matrices.
 
 # Arguments

--- a/src/Recognition/Recognition.jl
+++ b/src/Recognition/Recognition.jl
@@ -11,9 +11,9 @@ Algorithms for matrix bandwidth recognition in Julia.
 
 The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
 ``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
-has bandwidth *at most* ``k`` if all entries above the ``k``-th superdiagonal and below the
-``k``-th subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
-nonzero entry in the ``k``-th superdiagonal or subdiagonal.
+has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ superdiagonal and below the
+``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
+nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
 
 The *matrix bandwidth recognition problem* entails determining whether there exists a
 permutation matrix ``P`` such that the bandwidth of ``PAPᵀ`` is at most some fixed

--- a/src/Recognition/core.jl
+++ b/src/Recognition/core.jl
@@ -11,9 +11,9 @@ Determine whether `A` has bandwidth at most `k` using the algorithm defined by `
 
 The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
 ``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
-has bandwidth *at most* ``k`` if all entries above the ``k``-th superdiagonal and below the
-``k``-th subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
-nonzero entry in the ``k``-th superdiagonal or subdiagonal.
+has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ superdiagonal and below the
+``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
+nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
 
 Given some fixed non-negative integer `k`, this function determines (with 100% certainty)
 whether there exists some ordering ``π`` of the rows and columns of ``A`` such that the

--- a/src/core.jl
+++ b/src/core.jl
@@ -11,9 +11,9 @@ Compute the bandwidth of `A` before any permutation of its rows and columns.
 
 The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
 ``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
-has bandwidth *at most* ``k`` if all entries above the ``k``-th superdiagonal and below the
-``k``-th subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
-nonzero entry in the ``k``-th superdiagonal or subdiagonal.
+has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ superdiagonal and below the
+``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
+nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
 
 In contrast to [`minimize_bandwidth`](@ref), this function does not attempt to minimize the
 bandwidth of `A` by permuting its rows and columns—it simply computes its bandwidth as is.
@@ -109,9 +109,9 @@ adjacency matrices are symmetric).
 
 The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
 ``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
-has bandwidth *at most* ``k`` if all entries above the ``k``-th superdiagonal and below the
-``k``-th subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
-nonzero entry in the ``k``-th superdiagonal or subdiagonal.
+has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ superdiagonal and below the
+``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
+nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
 
 In contrast to [`minimize_bandwidth`](@ref), this function does not attempt to truly
 minimize the bandwidth of `A`—it simply returns a lower bound on its bandwidth up to

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,11 +11,11 @@ Generate a random `n×n` structurally symmetric `k`-banded matrix with band dens
 
 By definition of structural symmetry, the ``(i, j)``-th entry of the matrix is nonzero if
 and only if the ``(j, i)``-th entry is nonzero as well. All entries from this matrix are
-from the interval `[0, 1]`. Entries up to the `k`-th superdiagonal and down to the `k`-th
+from the interval `[0, 1]`. Entries up to the `k`ᵗʰ superdiagonal and down to the `k`ᵗʰ
 subdiagonal are nonzero with probability `p`.
 
 It is also guaranteed that each of these bands (besides the main diagonal) has at least one
-nonzero entry (even when `p` is very small), thus ensuring that th matrix has bandwidth
+nonzero entry (even when `p` is very small), thus ensuring that the matrix has bandwidth
 precisely `k` before any reordering. (There may, however, still exist a symmetric
 permutation inducing a minimum bandwidth less than `k`, especially for small values of `p`.)
 
@@ -120,7 +120,7 @@ function random_banded_matrix(
         end
     end
 
-    #= Conditionally add entries to the superdiagonals and subdiagonals (up to the `k`-th)
+    #= Conditionally add entries to the superdiagonals and subdiagonals (up to the `k`ᵗʰ)
     based on the band density `p`. =#
     for d in 1:k
         feasible_indices = 1:(n - d)
@@ -132,7 +132,7 @@ function random_banded_matrix(
             end
         end
 
-        #= Ensure that the `d`-th superdiagonal and subdiagonal each have at least one
+        #= Ensure that the `d`ᵗʰ superdiagonal and subdiagonal each have at least one
         nonzero entry for `1 ≤ d ≤ k`, making a `bandwidth < k` symmetric permutation less
         likely. (Given structural symmetry, we need only check for empty superdiagonals.) =#
         if iszero(map(i -> A[i, i + d], feasible_indices))


### PR DESCRIPTION
This PR adds 'Basic use' and 'Documentation' sections to the README (and to the Documenter website), taking inspiration from the Graphs.jl package. It also fixes several typos/makes a few stylistic changes to existing docstrings in the package that were identified in the process.

(Resolves #46.)