### PR TITLE
Rename 'BruteForce' -> 'BruteForceSearch'

### DIFF
--- a/src/MatrixBandwidth.jl
+++ b/src/MatrixBandwidth.jl
@@ -36,7 +36,7 @@ The following algorithms are currently supported:
         - Del Corso–Manzini algorithm with perimeter search
             ([`Minimization.DelCorsoManziniWithPS`](@ref))
         - Saxe–Gurari–Sudborough algorithm ([`Minimization.SaxeGurariSudborough`](@ref))
-        - Brute-force search ([`Minimization.BruteForce`](@ref))
+        - Brute-force search ([`Minimization.BruteForceSearch`](@ref))
     - *Heuristic*
         - Gibbs–Poole–Stockmeyer algorithm ([`Minimization.GibbsPooleStockmeyer`](@ref))
         - Cuthill–McKee algorithm ([`Minimization.CuthillMcKee`](@ref))
@@ -51,7 +51,7 @@ The following algorithms are currently supported:
     - Del Corso–Manzini algorithm with perimeter search
         ([`Recognition.DelCorsoManziniWithPS`](@ref))
     - Saxe–Gurari–Sudborough algorithm ([`Recognition.SaxeGurariSudborough`](@ref))
-    - Brute-force search ([`Recognition.BruteForce`](@ref))
+    - Brute-force search ([`Recognition.BruteForceSearch`](@ref))
 
 [Full documentation](https://Luis-Varona.github.io/MatrixBandwidth.jl/dev/) is available for
 the latest development version of this package.

--- a/src/Minimization/Exact/Exact.jl
+++ b/src/Minimization/Exact/Exact.jl
@@ -21,7 +21,7 @@ The following exact algorithms are currently supported:
 - Del Corso–Manzini algorithm ([`DelCorsoManzini`](@ref))
 - Del Corso–Manzini algorithm with perimeter search ([`DelCorsoManziniWithPS`](@ref))
 - Saxe–Gurari–Sudborough algorithm ([`SaxeGurariSudborough`](@ref))
-- Brute-force search ([`BruteForce`](@ref))
+- Brute-force search ([`BruteForceSearch`](@ref))
 
 This submodule is part of the `MatrixBandwidth.Minimization` submodule of the
 [MatrixBandwidth.jl](https://github.com/Luis-Varona/MatrixBandwidth.jl) package.
@@ -40,7 +40,7 @@ import .._approach, .._bool_minimal_band_ordering
 using Combinatorics
 
 export CapraraSalazarGonzalez,
-    DelCorsoManzini, DelCorsoManziniWithPS, SaxeGurariSudborough, BruteForce
+    DelCorsoManzini, DelCorsoManziniWithPS, SaxeGurariSudborough, BruteForceSearch
 
 include("types.jl")
 

--- a/src/Minimization/Exact/solvers/brute_force.jl
+++ b/src/Minimization/Exact/solvers/brute_force.jl
@@ -5,7 +5,7 @@
 # distributed except according to those terms.
 
 """
-    BruteForce <: ExactSolver <: AbstractSolver <: AbstractAlgorithm
+    BruteForceSearch <: ExactSolver <: AbstractSolver <: AbstractAlgorithm
 
 The simplest exact method for minimizing the bandwidth of a matrix is to iterate over all
 possible symmetric permutations and compare the bandwidths they induce.
@@ -28,13 +28,13 @@ Given an ``n×n`` input matrix ``A``, this brute-force algorithm runs in ``O(n! 
 Brute force is by far the slowest approach to matrix bandwidth minimization and should only
 be used in very niche cases like writing unit tests for other non-naïve algorithms.
 """
-struct BruteForce <: ExactSolver end
+struct BruteForceSearch <: ExactSolver end
 
-Base.summary(::BruteForce) = "Brute-force search"
+Base.summary(::BruteForceSearch) = "Brute-force search"
 
-_requires_symmetry(::BruteForce) = false
+_requires_symmetry(::BruteForceSearch) = false
 
-function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::BruteForce)
+function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::BruteForceSearch)
     #= `i₁, i₂, … iₙ` induces the same bandwidth as `iₙ, iₙ₋₁, … i₁`, so without loss of
     generality, we restrict our search to orderings such that `i₁ ≤ iₙ` (with equality
     checked just in case `n = 1`). =#

--- a/src/Minimization/Minimization.jl
+++ b/src/Minimization/Minimization.jl
@@ -28,7 +28,7 @@ The following algorithms are currently supported:
     - Del Corso–Manzini algorithm ([`DelCorsoManzini`](@ref))
     - Del Corso–Manzini algorithm with perimeter search ([`DelCorsoManziniWithPS`](@ref))
     - Saxe–Gurari–Sudborough algorithm ([`SaxeGurariSudborough`](@ref))
-    - Brute-force search ([`BruteForce`](@ref))
+    - Brute-force search ([`BruteForceSearch`](@ref))
 - *Heuristic*
     - Gibbs–Poole–Stockmeyer algorithm ([`GibbsPooleStockmeyer`](@ref))
     - Cuthill–McKee algorithm ([`CuthillMcKee`](@ref))
@@ -67,7 +67,7 @@ export CapraraSalazarGonzalez, # Exact solvers
     DelCorsoManzini,
     DelCorsoManziniWithPS,
     SaxeGurariSudborough,
-    BruteForce
+    BruteForceSearch
 export GibbsPooleStockmeyer, CuthillMcKee, ReverseCuthillMcKee # Heuristic solvers
 export SimulatedAnnealing, GeneticAlgorithm, GRASP # Metaheuristic solvers
 

--- a/src/Recognition/Recognition.jl
+++ b/src/Recognition/Recognition.jl
@@ -26,7 +26,7 @@ The following algorithms are currently supported:
 - Del Corso–Manzini algorithm ([`DelCorsoManzini`](@ref))
 - Del Corso–Manzini algorithm with perimeter search ([`DelCorsoManziniWithPS`](@ref))
 - Saxe–Gurari–Sudborough algorithm ([`SaxeGurariSudborough`](@ref))
-- Brute-force search ([`BruteForce`](@ref))
+- Brute-force search ([`BruteForceSearch`](@ref))
 
 This submodule is part of the
 [MatrixBandwidth.jl](https://github.com/Luis-Varona/MatrixBandwidth.jl) package.
@@ -50,7 +50,7 @@ export CapraraSalazarGonzalez, # Recognition algorithms
     DelCorsoManzini,
     DelCorsoManziniWithPS,
     SaxeGurariSudborough,
-    BruteForce
+    BruteForceSearch
 
 include("types.jl")
 include("core.jl")

--- a/src/Recognition/deciders/brute_force.jl
+++ b/src/Recognition/deciders/brute_force.jl
@@ -5,7 +5,7 @@
 # distributed except according to those terms.
 
 """
-    BruteForce <: AbstractDecider <: AbstractAlgorithm
+    BruteForceSearch <: AbstractDecider <: AbstractAlgorithm
 
 The simplest method for determining, given some fixed ``k ∈ ℕ``, whether a matrix has
 bandwidth at most ``k`` up to symmetric permutation is to iterate over all orderings and
@@ -32,15 +32,15 @@ Given an ``n×n`` input matrix ``A``, this brute-force algorithm runs in ``O(n! 
 Brute force is by far the slowest approach to matrix bandwidth recognition and should only
 be used in very niche cases like writing unit tests for other non-naïve algorithms.
 """
-struct BruteForce <: AbstractDecider end
+struct BruteForceSearch <: AbstractDecider end
 
-Base.summary(::BruteForce) = "Brute-force search"
+Base.summary(::BruteForceSearch) = "Brute-force search"
 
-_requires_symmetry(::BruteForce) = false
+_requires_symmetry(::BruteForceSearch) = false
 
 #= We take advantage of the laziness of `permutations` and `Iterators.filter` to avoid
 iterating over all orderings if a valid one is found early. =#
-function _bool_bandwidth_k_ordering(A::AbstractMatrix{Bool}, k::Int, ::BruteForce)
+function _bool_bandwidth_k_ordering(A::AbstractMatrix{Bool}, k::Int, ::BruteForceSearch)
     #= `i₁, i₂, … iₙ` induces the same bandwidth as `iₙ, iₙ₋₁, … i₁`, so without loss of
     generality, we restrict our search to orderings such that `i₁ ≤ iₙ` (with equality
     checked just in case `n = 1`). =#

--- a/src/core.jl
+++ b/src/core.jl
@@ -143,7 +143,7 @@ julia> A = sprand(n, n, p);
 
 julia> A = A + A'; # Make `A` structurally symmetric
 
-julia> minimize_bandwidth(A, Minimization.BruteForce()).bandwidth # Foolproof algorithm
+julia> minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
 5
 
 julia> bandwidth_lower_bound(A) # Always less than or equal to the true minimum bandwidth

--- a/test/Minimization/Exact/solvers/del_corso_manzini.jl
+++ b/test/Minimization/Exact/solvers/del_corso_manzini.jl
@@ -26,7 +26,7 @@ const NUM_ITER = 100
         A = sprand(n, n, density)
         A = A + A' # Make `A` structurally symmetric
 
-        res_bf = minimize_bandwidth(A, BruteForce())
+        res_bf = minimize_bandwidth(A, BruteForceSearch())
         res_dcm = minimize_bandwidth(A, DelCorsoManzini())
         ordering_dcm = res_dcm.ordering
 
@@ -42,7 +42,7 @@ end
         A = sprand(n, n, density)
         A = A + A' # Make `A` structurally symmetric
 
-        res_bf = minimize_bandwidth(A, BruteForce())
+        res_bf = minimize_bandwidth(A, BruteForceSearch())
         res_dcm = minimize_bandwidth(A, DelCorsoManziniWithPS())
         ordering_dcm = res_dcm.ordering
 
@@ -59,7 +59,7 @@ end
         A = A + A' # Make `A` structurally symmetric
         depth = rand(1:n)
 
-        res_bf = minimize_bandwidth(A, BruteForce())
+        res_bf = minimize_bandwidth(A, BruteForceSearch())
         res_dcm = minimize_bandwidth(A, DelCorsoManziniWithPS(depth))
         ordering_dcm = res_dcm.ordering
 

--- a/test/Recognition/deciders/del_corso_manzini.jl
+++ b/test/Recognition/deciders/del_corso_manzini.jl
@@ -31,7 +31,7 @@ const NUM_ITER = 100
             A = A + A' # Make `A` structurally symmetric
         end
 
-        b = minimize_bandwidth(A, Minimization.BruteForce()).bandwidth
+        b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
         k = rand(0:(b - 1))
 
         res = has_bandwidth_k_ordering(A, k, DelCorsoManzini())
@@ -53,7 +53,7 @@ end
             A = A + A' # Make `A` structurally symmetric
         end
 
-        b = minimize_bandwidth(A, Minimization.BruteForce()).bandwidth
+        b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
         k = rand(0:(b - 1))
 
         res = has_bandwidth_k_ordering(A, k, DelCorsoManziniWithPS())
@@ -75,7 +75,7 @@ end
             A = A + A' # Make `A` structurally symmetric
         end
 
-        b = minimize_bandwidth(A, Minimization.BruteForce()).bandwidth
+        b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
         k = rand(0:(b - 1))
         depth = rand(1:n)
 
@@ -92,7 +92,7 @@ end
         A = sprand(n, n, density)
         A = A + A' # Make `A` structurally symmetric
 
-        b = minimize_bandwidth(A, Minimization.BruteForce()).bandwidth
+        b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
         k = rand(b:(n - 1))
 
         res = has_bandwidth_k_ordering(A, k, DelCorsoManzini())
@@ -109,7 +109,7 @@ end
         A = sprand(n, n, density)
         A = A + A' # Make `A` structurally symmetric
 
-        b = minimize_bandwidth(A, Minimization.BruteForce()).bandwidth
+        b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
         k = rand(b:(n - 1))
 
         res = has_bandwidth_k_ordering(A, k, DelCorsoManziniWithPS())
@@ -126,7 +126,7 @@ end
         A = sprand(n, n, density)
         A = A + A' # Make `A` structurally symmetric
 
-        b = minimize_bandwidth(A, Minimization.BruteForce()).bandwidth
+        b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
         k = rand(b:(n - 1))
         depth = rand(1:n)
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -41,7 +41,7 @@ end
         A = A + A' # Make `A` structurally symmetric
 
         k = bandwidth_lower_bound(A)
-        res = minimize_bandwidth(A, BruteForce())
+        res = minimize_bandwidth(A, BruteForceSearch())
 
         @test k <= res.bandwidth
     end


### PR DESCRIPTION
This PR renames all occurrences of 'BruteForce' (a solver/decider name) to 'BruteForceSearch' for clarity and consistency with the rest of the AbstractAlgorithm naming conventions.

(Fixes #47.)