### PR TITLE
Replace some TODO's with errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The following algorithms are currently supported:
   - Saxe&ndash;Gurari&ndash;Sudborough algorithm
   - Brute-force search
 
-(As we remain in the early stages of development, some of these may not yet be fully implemented and/or tested.)
+(As we remain in the early stages of development, some of these may not yet be fully implemented and/or tested. Whenever an unimplemented algorithm is used, an `ERROR: TODO: Not yet implemented` is raised.)
 
 ## Installation
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -77,7 +77,7 @@ The following algorithms are currently supported:
   - Saxe–Gurari–Sudborough algorithm
   - Brute-force search
 
-(As we remain in the early stages of development, some of these may not yet be fully implemented and/or tested.)
+(As we remain in the early stages of development, some of these may not yet be fully implemented and/or tested. Whenever an unimplemented algorithm is used, an `ERROR: TODO: Not yet implemented` is raised.)
 
 ## Installation
 

--- a/src/Minimization/Exact/solvers/caprara_salazar_gonzalez.jl
+++ b/src/Minimization/Exact/solvers/caprara_salazar_gonzalez.jl
@@ -40,6 +40,6 @@ Base.summary(::CapraraSalazarGonzalez) = "Caprara–Salazar-González"
 _requires_symmetry(::CapraraSalazarGonzalez) = true
 
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::CapraraSalazarGonzalez)
-    # TODO: Implement
-    return Int[]
+    error("TODO: Not yet implemented")
+    return nothing
 end

--- a/src/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
+++ b/src/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
@@ -16,6 +16,6 @@ Base.summary(::SaxeGurariSudborough) = "Saxe–Gurari–Sudborough"
 _requires_symmetry(::SaxeGurariSudborough) = true
 
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::SaxeGurariSudborough)
-    # TODO: Implement
-    return Int[]
+    error("TODO: Not yet implemented")
+    return nothing
 end

--- a/src/Minimization/Heuristic/solvers/gibbs_poole_stockmeyer.jl
+++ b/src/Minimization/Heuristic/solvers/gibbs_poole_stockmeyer.jl
@@ -7,7 +7,7 @@
 """
     GibbsPooleStockmeyer <: HeuristicSolver <: AbstractSolver <: AbstractAlgorithm
 
-TODO: Write here. Do we need a node selector?
+[TODO: Write here. Do we need a node selector?]
 """
 struct GibbsPooleStockmeyer <: HeuristicSolver end
 
@@ -16,7 +16,6 @@ Base.summary(::GibbsPooleStockmeyer) = "Gibbs–Poole–Stockmeyer"
 _requires_symmetry(::GibbsPooleStockmeyer) = true
 
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, solver::GibbsPooleStockmeyer)
-    # TODO: Implement
-
-    return Int[]
+    error("TODO: Not yet implemented")
+    return nothing
 end

--- a/src/Minimization/Metaheuristic/solvers/genetic_algorithm.jl
+++ b/src/Minimization/Metaheuristic/solvers/genetic_algorithm.jl
@@ -7,7 +7,7 @@
 """
     GeneticAlgorithm <: MetaheuristicSolver <: AbstractSolver <: AbstractAlgorithm
 
-TODO: Write here
+[TODO: Write here]
 """
 struct GeneticAlgorithm <: MetaheuristicSolver
     # TODO: Define fields and constructor (for default values)
@@ -18,5 +18,6 @@ Base.summary(::GeneticAlgorithm) = "Genetic algorithm"
 _requires_symmetry(::GeneticAlgorithm) = false
 
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, solver::GeneticAlgorithm)
-    # TODO: Implement
+    error("TODO: Not yet implemented")
+    return nothing
 end

--- a/src/Minimization/Metaheuristic/solvers/grasp.jl
+++ b/src/Minimization/Metaheuristic/solvers/grasp.jl
@@ -7,7 +7,7 @@
 """
     GRASP <: MetaheuristicSolver <: AbstractSolver <: AbstractAlgorithm
 
-TODO: Write here
+[TODO: Write here]
 """
 struct GRASP <: MetaheuristicSolver
     # TODO: Define fields and constructor (for default values)
@@ -18,5 +18,6 @@ Base.summary(::GRASP) = "Greedy randomized adaptive search procedure (GRASP)"
 _requires_symmetry(::GRASP) = false
 
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, Solver::GRASP)
-    # TODO: Implement
+    error("TODO: Not yet implemented")
+    return nothing
 end

--- a/src/Minimization/Metaheuristic/solvers/simulated_annealing.jl
+++ b/src/Minimization/Metaheuristic/solvers/simulated_annealing.jl
@@ -7,7 +7,7 @@
 """
     SimulatedAnnealing <: MetaheuristicSolver <: AbstractSolver <: AbstractAlgorithm
 
-TODO: Write here
+[TODO: Write here]
 """
 struct SimulatedAnnealing <: MetaheuristicSolver
     initial_temp::Float64
@@ -24,5 +24,6 @@ Base.summary(::SimulatedAnnealing) = "Simulated annealing"
 _requires_symmetry(::SimulatedAnnealing) = false
 
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, solver::SimulatedAnnealing)
-    # TODO: Implement
+    error("TODO: Not yet implemented")
+    return nothing
 end

--- a/src/Recognition/deciders/caprara_salazar_gonzalez.jl
+++ b/src/Recognition/deciders/caprara_salazar_gonzalez.jl
@@ -45,5 +45,6 @@ _requires_symmetry(::CapraraSalazarGonzalez) = true
 function _bool_bandwidth_k_ordering(
     A::AbstractMatrix{Bool}, k::Int, ::CapraraSalazarGonzalez
 )
-    # TODO: Implement
+    error("TODO: Not yet implemented")
+    return nothing
 end

--- a/src/Recognition/deciders/saxe_gurari_sudborough.jl
+++ b/src/Recognition/deciders/saxe_gurari_sudborough.jl
@@ -7,12 +7,13 @@
 """
     SaxeGurariSudborough <: AbstractDecider <: AbstractAlgorithm
 
-TODO: Write here
+[TODO: Write here]
 """
 struct SaxeGurariSudborough <: AbstractDecider end
 
 Base.summary(::SaxeGurariSudborough) = "Saxe–Gurari–Sudborough"
 
 function _bool_bandwidth_k_ordering(A::AbstractMatrix{Bool}, k::Int, ::SaxeGurariSudborough)
-    # TODO: Implement
+    error("TODO: Not yet implemented")
+    return nothing
 end


### PR DESCRIPTION
In critical parts of the code (e.g., mandatory method definitions for specific solvers/deciders), we replace 'TODO: Implement's with actual thrown errors. This is particularly important in stuff like CSG or GPS, which are default algorithms for recognition and minimization, so users are clear on the fact that this just has not been done yet. This pattern is clearly indicated in the 'Algorithms' section of the README (and documentation website) as well.

(As another minor related change, we also add square brackets around some other TODO's in docstrings.)