### PR TITLE
Flesh out docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ julia> A = sprand(30, 30, 0.05); A = A + A' # Ensure structural symmetry
 julia> res = has_bandwidth_k_ordering(A, 10, Recognition.DelCorsoManzini())
 Results of Bandwidth Recognition Algorithm
  * Algorithm: Del Corso–Manzini
- * k: 10
+ * Bandwidth Threshold k: 10
  * Has Bandwidth ≤ k Ordering: true
  * Original Bandwidth: 24
  * Matrix Size: 30×30

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,6 +22,8 @@ makedocs(;
         canonical="https://Luis-Varona.github.io/MatrixBandwidth.jl",
         edit_link="main",
         assets=["assets/styles.css"],
+        size_threshold=1_000_000,
+        size_threshold_warn=200_000,
     ),
     plugins=[bib],
     pages=[

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -150,7 +150,7 @@ julia> A = sprand(30, 30, 0.05); A = A + A' # Ensure structural symmetry
 julia> res = has_bandwidth_k_ordering(A, 10, Recognition.DelCorsoManzini())
 Results of Bandwidth Recognition Algorithm
  * Algorithm: Del Corso–Manzini
- * k: 10
+ * Bandwidth Threshold k: 10
  * Has Bandwidth ≤ k Ordering: true
  * Original Bandwidth: 24
  * Matrix Size: 30×30

--- a/src/Minimization/Exact/solvers/brute_force.jl
+++ b/src/Minimization/Exact/solvers/brute_force.jl
@@ -21,12 +21,43 @@ Given an ``n×n`` input matrix ``A``, this brute-force algorithm runs in ``O(n! 
     which takes ``O(n²)`` time.
 - Therefore, the overall time complexity is ``O(n! ⋅ n²)``.
 
+Indeed, due to the need to exhaustively check all permutations, this is close to a lower
+bound as well on the the algorithm's time complexity. (The only reason we cannot claim to
+have a precise value for the big-``Θ`` complexity is that the [`bandwidth`](@ref) function
+is not *exactly* ``Θ(n²)``, although it is close.)
+
 # Examples
-[TODO: Write here]
+The algorithm always iterates over all possible permutations, so it is infeasible to go
+above ``9×9`` or ``10×10`` without incurring multiple-hour runtimes. Nevertheless, we see
+that it is quite effective for, say, ``8×8``:
+```jldoctest
+julia> using Random, SparseArrays
+
+julia> Random.seed!(628318);
+
+julia> (n, p) = (8, 0.2);
+
+julia> A = sprand(Bool, n, n, p);
+
+julia> A = A + A' # Ensure structural symmetry;
+
+julia> minimize_bandwidth(A, Minimization.BruteForceSearch())
+Results of Bandwidth Minimization Algorithm
+ * Algorithm: Brute-force search
+ * Approach: exact
+ * Minimum Bandwidth: 3
+ * Original Bandwidth: 6
+ * Matrix Size: 8×8
+```
 
 # Notes
 Brute force is by far the slowest approach to matrix bandwidth minimization and should only
-be used in very niche cases like writing unit tests for other non-naïve algorithms.
+be used in very niche cases (like verifying the correctness of other algorithms in unit
+tests). For ``10×10`` matrices, the algorithm already takes several minutes to run (between
+``2`` to ``5`` on most commercial machines) and allocates over ``4`` gigabytes of memory.
+Given the ``O(n! ⋅ n²)`` time complexity, minimizing the bandwidth of any ``11×11`` matrix
+would take over an hour.
+
 """
 struct BruteForceSearch <: ExactSolver end
 

--- a/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
+++ b/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
@@ -47,8 +47,7 @@ the true minimum bandwidth up to symmetric permutation may be even less than ``k
 it hard to verify whether Cuthill–McKee finds a truly optimal ordering or simply a
 near-optimal one. Nevertheless, the results are still very good in practice.
 
-Cuthill–McKee finds a good ordering for a ``30×30`` matrix whose rows and columns have been
-shuffled:
+Cuthill–McKee finds a good ordering for a ``30×30`` matrix:
 ```jldoctest
 julia> using Random
 
@@ -68,7 +67,7 @@ julia> bandwidth(A)
 julia> bandwidth(A_shuffled) # Much larger after shuffling
 25
 
-julia> res = minimize_bandwidth(A_shuffled, Minimization.CuthillMcKee())
+julia> minimize_bandwidth(A_shuffled, Minimization.CuthillMcKee())
 Results of Bandwidth Minimization Algorithm
  * Algorithm: Cuthill–McKee
  * Approach: heuristic
@@ -78,7 +77,7 @@ Results of Bandwidth Minimization Algorithm
 ```
 
 Cuthill–McKee finds a good ordering for a structurally symmetric ``183×183`` matrix with
-multiple (separate) connected components whose rows and columns have been shuffled:
+multiple (separate) connected components:
 ```jldoctest
 julia> using Random, SparseArrays
 
@@ -250,8 +249,7 @@ the true minimum bandwidth up to symmetric permutation may be even less than ``k
 it hard to verify whether reverse Cuthill–McKee finds a truly optimal ordering or simply a
 near-optimal one. Nevertheless, the results are still very good in practice.
 
-Reverse Cuthill–McKee finds a good ordering for a ``35×35`` matrix whose rows and columns
-have been shuffled:
+Reverse Cuthill–McKee finds a good ordering for a ``35×35`` matrix:
 ```jldoctest
 julia> using Random
 
@@ -271,7 +269,7 @@ julia> bandwidth(A)
 julia> bandwidth(A_shuffled) # Much larger after shuffling
 30
 
-julia> res = minimize_bandwidth(A_shuffled, Minimization.ReverseCuthillMcKee())
+julia> minimize_bandwidth(A_shuffled, Minimization.ReverseCuthillMcKee())
 Results of Bandwidth Minimization Algorithm
  * Algorithm: Reverse Cuthill–McKee
  * Approach: heuristic
@@ -281,7 +279,7 @@ Results of Bandwidth Minimization Algorithm
 ```
 
 Reverse Cuthill–McKee finds a good ordering for a ``235×235`` matrix with multiple
-(separate) connected components whose rows and columns have been shuffled:
+(separate) connected components:
 ```jldoctest
 julia> using Random, SparseArrays
 

--- a/src/Recognition/deciders/brute_force.jl
+++ b/src/Recognition/deciders/brute_force.jl
@@ -26,11 +26,58 @@ Given an ``n×n`` input matrix ``A``, this brute-force algorithm runs in ``O(n! 
 - Therefore, the overall time complexity is ``O(n! ⋅ n²)``.
 
 # Examples
-[TODO: Write here]
+In many cases, the algorithm iterates over all (if ``k`` is smaller than the true minimu
+bandwidth) or almost all (if ``k`` is equally to or only slightly larger than the true
+minimum) possible permutations—in these cases, it is infeasible to go above ``9×9`` or
+``10×10`` without incurring multiple-hour runtimes. (Even when ``k`` is considerably larger
+than the true minimum, it is unlikely that a bandwidth-``k`` ordering will be found in a
+reasonable time frame.) Nevertheless, we see that it is quite effective for, say, ``8×8``:
+```jldoctest
+julia> using Random, SparseArrays
+
+julia> Random.seed!(314159);
+
+julia> (n, p) = (8, 0.5);
+
+julia> A = sprand(Bool, n, n, p);
+
+julia> A = A + A' # Ensure structural symmetry;
+
+julia> (k_false, k_true) = (3, 5);
+
+julia> has_bandwidth_k_ordering(A, k_false, Recognition.BruteForceSearch())
+Results of Bandwidth Recognition Algorithm
+ * Algorithm: Brute-force search
+ * Bandwidth Threshold k: 3
+ * Has Bandwidth ≤ k Ordering: false
+ * Original Bandwidth: 6
+ * Matrix Size: 8×8
+
+julia> has_bandwidth_k_ordering(A, k_true, Recognition.BruteForceSearch())
+Results of Bandwidth Recognition Algorithm
+ * Algorithm: Brute-force search
+ * Bandwidth Threshold k: 5
+ * Has Bandwidth ≤ k Ordering: true
+ * Original Bandwidth: 6
+ * Matrix Size: 8×8
+```
 
 # Notes
-Brute force is by far the slowest approach to matrix bandwidth recognition and should only
-be used in very niche cases like writing unit tests for other non-naïve algorithms.
+Brute force is by far the slowest approach to matrix bandwidth minimization and should only
+be used in very niche cases (like verifying the correctness of other algorithms in unit
+tests). For ``10×10`` matrices, the algorithm already takes several minutes to run for
+difficult values of ``k`` (namely, values below or only slightly above the true minimum) and
+allocates several gigabytes of memory. Given the ``O(n! ⋅ n²)`` time complexity, checking
+"bandwidth ≤ k" would take over an hour for many ``11×11`` matrices.
+
+This holds true even when ``k`` is considerably larger than the true minimum bandwidth—as
+long as it remains below the bandwidth induced by the original ordering, it is unlikely that
+a bandwidth-``k`` ordering will be found early simply by random chance. Additionally, time
+complexity will remain on the order of ``n! ⋅ n²`` in the average case.
+
+See also [`MatrixBandwidth.Minimization.Exact.BruteForceSearch`](@ref) for the minimization
+variant of this algorithm (which simply never breaks early, instead iterating over all
+permutations up to reversal to ensure that the minimum bandwidth is found).
 """
 struct BruteForceSearch <: AbstractDecider end
 

--- a/src/Recognition/types.jl
+++ b/src/Recognition/types.jl
@@ -68,7 +68,7 @@ function Base.show(io::IO, res::RecognitionResult)
 
     println(io, "Results of Bandwidth Recognition Algorithm")
     println(io, " * Algorithm: $(summary(res.algorithm))")
-    println(io, " * k: $(res.k)")
+    println(io, " * Bandwidth Threshold k: $(res.k)")
     println(io, " * Has Bandwidth ≤ k Ordering: $(res.has_ordering)")
     println(io, " * Original Bandwidth: $(bandwidth(res.matrix))")
     print(io, " * Matrix Size: $n×$n")

--- a/src/core.jl
+++ b/src/core.jl
@@ -132,7 +132,7 @@ in ``O(n²)`` time).
 # Examples
 The function correctly computes a bound less than (or equal to) the true minimum bandwidth
 of a matrix up to symmetric permutation:
-```julia
+```jldoctest
 julia> using Random, SparseArrays, Combinatorics
 
 julia> Random.seed!(21);
@@ -141,10 +141,15 @@ julia> (n, p) = (9, 0.4);
 
 julia> A = sprand(n, n, p);
 
-julia> A = A + A'; # Make `A` structurally symmetric
+julia> A = A + A' # Ensure structural symmetry;
 
-julia> minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
-5
+julia> minimize_bandwidth(A, Minimization.BruteForceSearch())
+Results of Bandwidth Minimization Algorithm
+ * Algorithm: Brute-force search
+ * Approach: exact
+ * Minimum Bandwidth: 5
+ * Original Bandwidth: 8
+ * Matrix Size: 9×9
 
 julia> bandwidth_lower_bound(A) # Always less than or equal to the true minimum bandwidth
 4

--- a/test/Minimization/Exact/solvers/del_corso_manzini.jl
+++ b/test/Minimization/Exact/solvers/del_corso_manzini.jl
@@ -24,7 +24,7 @@ const NUM_ITER = 100
     for n in 1:MAX_ORDER, _ in 1:NUM_ITER
         density = rand()
         A = sprand(n, n, density)
-        A = A + A' # Make `A` structurally symmetric
+        A = A + A' # Ensure structural symmetry
 
         res_bf = minimize_bandwidth(A, BruteForceSearch())
         res_dcm = minimize_bandwidth(A, DelCorsoManzini())
@@ -40,7 +40,7 @@ end
     for n in 1:MAX_ORDER, _ in 1:NUM_ITER
         density = rand()
         A = sprand(n, n, density)
-        A = A + A' # Make `A` structurally symmetric
+        A = A + A' # Ensure structural symmetry
 
         res_bf = minimize_bandwidth(A, BruteForceSearch())
         res_dcm = minimize_bandwidth(A, DelCorsoManziniWithPS())
@@ -56,7 +56,7 @@ end
     for n in 1:MAX_ORDER, _ in 1:NUM_ITER
         density = rand()
         A = sprand(n, n, density)
-        A = A + A' # Make `A` structurally symmetric
+        A = A + A' # Ensure structural symmetry
         depth = rand(1:n)
 
         res_bf = minimize_bandwidth(A, BruteForceSearch())

--- a/test/Recognition/deciders/del_corso_manzini.jl
+++ b/test/Recognition/deciders/del_corso_manzini.jl
@@ -23,12 +23,12 @@ const NUM_ITER = 100
     for n in 2:MAX_ORDER, i in 1:NUM_ITER
         density = rand()
         A = sprand(n, n, density)
-        A = A + A' # Make `A` structurally symmetric
+        A = A + A' # Ensure structural symmetry
 
         while bandwidth(A) == 0
             density = rand()
             A = sprand(n, n, density)
-            A = A + A' # Make `A` structurally symmetric
+            A = A + A' # Ensure structural symmetry
         end
 
         b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
@@ -45,12 +45,12 @@ end
     for n in 2:MAX_ORDER, _ in 1:NUM_ITER
         density = rand()
         A = sprand(n, n, density)
-        A = A + A' # Make `A` structurally symmetric
+        A = A + A' # Ensure structural symmetry
 
         while bandwidth(A) == 0
             density = rand()
             A = sprand(n, n, density)
-            A = A + A' # Make `A` structurally symmetric
+            A = A + A' # Ensure structural symmetry
         end
 
         b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
@@ -67,12 +67,12 @@ end
     for n in 2:MAX_ORDER, _ in 1:NUM_ITER
         density = rand()
         A = sprand(n, n, density)
-        A = A + A' # Make `A` structurally symmetric
+        A = A + A' # Ensure structural symmetry
 
         while bandwidth(A) == 0
             density = rand()
             A = sprand(n, n, density)
-            A = A + A' # Make `A` structurally symmetric
+            A = A + A' # Ensure structural symmetry
         end
 
         b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
@@ -90,7 +90,7 @@ end
     for n in 1:MAX_ORDER, _ in 1:NUM_ITER
         density = rand()
         A = sprand(n, n, density)
-        A = A + A' # Make `A` structurally symmetric
+        A = A + A' # Ensure structural symmetry
 
         b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
         k = rand(b:(n - 1))
@@ -107,7 +107,7 @@ end
     for n in 1:MAX_ORDER, _ in 1:NUM_ITER
         density = rand()
         A = sprand(n, n, density)
-        A = A + A' # Make `A` structurally symmetric
+        A = A + A' # Ensure structural symmetry
 
         b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
         k = rand(b:(n - 1))
@@ -124,7 +124,7 @@ end
     for n in 1:MAX_ORDER, _ in 1:NUM_ITER
         density = rand()
         A = sprand(n, n, density)
-        A = A + A' # Make `A` structurally symmetric
+        A = A + A' # Ensure structural symmetry
 
         b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
         k = rand(b:(n - 1))

--- a/test/core.jl
+++ b/test/core.jl
@@ -38,7 +38,7 @@ end
     for n in 1:MAX_ORDER2, _ in 1:NUM_ITER2
         density = rand()
         A = sprand(n, n, density)
-        A = A + A' # Make `A` structurally symmetric
+        A = A + A' # Ensure structural symmetry
 
         k = bandwidth_lower_bound(A)
         res = minimize_bandwidth(A, BruteForceSearch())
@@ -51,7 +51,7 @@ end
     for n in 1:MAX_ORDER1, _ in 1:NUM_ITER1
         density = rand()
         A = sprand(Bool, n, n, density)
-        A = A .|| A' # Make `A` structurally symmetric
+        A = A .|| A' # Ensure structural symmetry
         g = Graph(A)
 
         res_matband = MatrixBandwidth._floyd_warshall_shortest_paths(A)


### PR DESCRIPTION
Incomplete docstrings for several recently completed algorithms are finished (particularly the 'Examples' and 'Notes' sections). Several wordings and other doctests are also fixed throughout.

On a final note, the 'Base.show' method override for the AbstractDecider type is also tweaked, changing the 'k: ...' line to 'Threshold Bandwidth k: ...'.