### PR TITLE
Add `utils` tests/clarify core examples

### DIFF
--- a/src/Minimization/core.jl
+++ b/src/Minimization/core.jl
@@ -34,7 +34,9 @@ complexity and thus only feasible for relatively small matrices.
     the (near-)optimal ordering of the rows and columns, and the minimized bandwidth.
 
 # Examples
-[TODO: Add here once more solvers are implemented]
+[TODO: Add here once more solvers are implemented. For now, refer to the **Examples**
+sections of the [`GibbsPooleStockmeyer`](@ref), [`CuthillMcKee`](@ref), and
+[`ReverseCuthillMcKee`](@ref) docstrings.]
 
 # Notes
 Some texts define matrix bandwidth to be the minimum non-negative integer ``k`` such that

--- a/src/Recognition/core.jl
+++ b/src/Recognition/core.jl
@@ -40,7 +40,8 @@ Caprara and Salazar-González (2005). If this lower bound is greater than ``k```
     `k`, and a boolean indicating whether the ordering exists.
 
 # Examples
-[TODO: Add here once more deciders are implemented]
+[TODO: Add here once more deciders are implemented. For now, refer to the **Examples**
+sections of the [`DelCorsoManzini`](@ref) and [`DelCorsoManziniWithPS`](@ref) docstrings.]
 
 # Notes
 Some texts define matrix bandwidth to be the minimum non-negative integer ``k`` such that

--- a/test/core.jl
+++ b/test/core.jl
@@ -23,7 +23,7 @@ const NUM_ITER1 = 100
 const MAX_ORDER2 = 8
 const NUM_ITER2 = 10
 
-@testset "Testing `bandwidth` (n ≤ $MAX_ORDER1)" begin
+@testset "`bandwidth` (n ≤ $MAX_ORDER1)" begin
     for n in 1:MAX_ORDER1, _ in 1:NUM_ITER1
         density = rand()
         A = sprand(n, n, density)
@@ -34,7 +34,7 @@ const NUM_ITER2 = 10
     end
 end
 
-@testset "Testing `bandwidth_lower_bound` (n ≤ $MAX_ORDER2)" begin
+@testset "`bandwidth_lower_bound` (n ≤ $MAX_ORDER2)" begin
     for n in 1:MAX_ORDER2, _ in 1:NUM_ITER2
         density = rand()
         A = sprand(n, n, density)
@@ -47,7 +47,7 @@ end
     end
 end
 
-@testset "Testing `_floyd_warshall_shortest_paths` (n ≤ $MAX_ORDER1)" begin
+@testset "`_floyd_warshall_shortest_paths` (n ≤ $MAX_ORDER1)" begin
     for n in 1:MAX_ORDER1, _ in 1:NUM_ITER1
         density = rand()
         A = sprand(Bool, n, n, density)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -7,34 +7,37 @@
 """
     TestUtils
 
-[TODO: Write here.]
+Test suite for the root-level utility functions of the `MatrixBandwidth.jl` package.
 """
 module TestUtils
 
 using MatrixBandwidth
 using Random
+using SparseArrays
 using Test
 
-const MAX_ORDER = 20
+const RBM_MAX_ORDER = 20
+const N = 100
+const P = 0.1
 
-@testset "Random banded matrices – Default density" begin
-    for n in 1:MAX_ORDER, k in 0:(n - 1)
+@testset "`random_banded_matrix` – Default density" begin
+    for n in 1:RBM_MAX_ORDER, k in 0:(n - 1)
         A = random_banded_matrix(n, k)
         @test bandwidth(A) == k
     end
 end
 
-@testset "Random banded matrices – Random densities" begin
-    for n in 1:MAX_ORDER, k in 0:(n - 1)
+@testset "`random_banded_matrix` – Random densities" begin
+    for n in 1:RBM_MAX_ORDER, k in 0:(n - 1)
         A = random_banded_matrix(n, k; p=rand())
         @test bandwidth(A) == k
     end
 end
 
-@testset "Random banded matrices – With RNGs" begin
+@testset "`random_banded_matrix` – With RNGs" begin
     rng = MersenneTwister(228)
 
-    for n in 1:MAX_ORDER, k in 0:(n - 1)
+    for n in 1:RBM_MAX_ORDER, k in 0:(n - 1)
         A = random_banded_matrix(n, k; rng=copy(rng))
         B = random_banded_matrix(n, k; rng=copy(rng))
 
@@ -52,10 +55,48 @@ end
 
 # TODO: Add tests for `random_banded_matrix` with full bands (`p = 1`)
 
-# TODO: Add tests for `_find_direct_subtype`
+@testset "`_find_direct_subtype`" begin
+    abstract type Parent end
 
-# TODO: Add tests for `_is_structurally_symmetric`
+    abstract type Child1 <: Parent end
+    abstract type Grandchild1 <: Child1 end
+    struct Grandchild2 <: Child1 end
 
-# TODO: Add tests for `_offdiag_nonzero_support`
+    abstract type Child2 <: Parent end
+    struct Child3 <: Parent end
+
+    @test MatrixBandwidth._find_direct_subtype(Parent, Child1) === Child1
+    @test MatrixBandwidth._find_direct_subtype(Parent, Grandchild1) === Child1
+    @test MatrixBandwidth._find_direct_subtype(Parent, Grandchild2) === Child1
+    @test MatrixBandwidth._find_direct_subtype(Parent, Child2) === Child2
+    @test MatrixBandwidth._find_direct_subtype(Parent, Child3) === Child3
+end
+
+@testset "`_is_structurally_symmetric`" begin
+    rng = MersenneTwister(787)
+    A = sprand(rng, N, N, P)
+    A = A + A' # Ensure structural symmetry
+
+    B = copy(A)
+    offdiag_nonzero_idx = first(
+        Iterators.filter(idx -> idx[1] != idx[2] && B[idx] != 0, CartesianIndices(B))
+    )
+    B[offdiag_nonzero_idx] = 0 # Break structural symmetry
+
+    @test MatrixBandwidth._is_structurally_symmetric(A)
+    @test !MatrixBandwidth._is_structurally_symmetric(B)
+end
+
+@testset "`_offdiag_nonzero_support`" begin
+    rng = MersenneTwister(887853)
+    A = sprand(rng, N, N, P)
+
+    offdiag_nonzero_idxs = MatrixBandwidth._offdiag_nonzero_support(A)
+    offdiag_zero_idxs = (!).(offdiag_nonzero_idxs)
+    foreach(i -> offdiag_zero_idxs[i, i] = false, 1:N)
+
+    @test all(!iszero, A[offdiag_nonzero_idxs])
+    @test iszero(A[offdiag_zero_idxs])
+end
 
 end


### PR DESCRIPTION
This PR nearly finishes the utils test suite, adding tests for all utility functions at the root level of the package. (The only things missing now are a few edge cases for `random_banded_matrix`.)

Additionally, the TODO's in the Examples sections of the `minimize_bandwidth` and `has_bandwidth_k_ordering` are clarified, pointing users to the Examples sections of specific solvers/deciders instead while we wait for all solvers and deciders to be implemented.