### PR TITLE
Prepare for first stable release, `v0.1.0`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ description = "Fast algorithms for matrix bandwidth minimization and matrix band
 maintainers = ["Luis M. B. Varona <lbvarona@mta.ca>"]
 readme = "README.md"
 repository = "https://github.com/Luis-Varona/MatrixBandwidth.jl"
-version = "0.1.0-beta"
+version = "0.1.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <tr>
     <td>Metadata</td>
     <td>
-      <img src="https://img.shields.io/badge/version-v0.1.0--beta-pink.svg" alt="Version">
+      <img src="https://img.shields.io/badge/version-v0.1.0-pink.svg" alt="Version">
       <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-A31F34.svg" alt="License: MIT"></a>
       <a href="https://github.com/JuliaDiff/BlueStyle"><img src="https://img.shields.io/badge/code%20style-blue-4495d1.svg" alt="Code Style: Blue"></a>
     </td>
@@ -73,7 +73,7 @@ The following algorithms are currently supported:
   - Saxe&ndash;Gurari&ndash;Sudborough algorithm [**under development**]
   - Brute-force search
 
-(As we remain in the early stages of development, some of these may not yet be fully implemented and/or tested. Whenever an unimplemented algorithm is used, an `ERROR: TODO: Not yet implemented` is raised.)
+(Although the API is already stable with the bulk of the library already functional and tested, a few algorithms remain under development. Whenever such an algorithm is used, the error `ERROR: TODO: Not yet implemented` is raised.)
 
 ## Installation
 
@@ -233,4 +233,4 @@ The latest citation information may be found in the [CITATION.bib](https://raw.g
 
 ## Project status
 
-I aim to release the first stable version of *MatrixBandwidth.jl* in late July 2025. The current version is a work-in-progress, with much of the API still under development.
+The first stable release of *MatrixBandwidth.jl*, `v0.1.0`, is now available. Although several algorithms are still under development, the bulk of the library is already functional and tested. I aim to complete development (including documentation and tests) of the remaining algorithms and other utility features by early August 2025.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,7 +7,7 @@ CurrentModule = MatrixBandwidth
   <tr>
     <td>Metadata</td>
     <td>
-      <img src="https://img.shields.io/badge/version-v0.1.0--beta-pink.svg" alt="Version">
+      <img src="https://img.shields.io/badge/version-v0.1.0-pink.svg" alt="Version">
       <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-A31F34.svg" alt="License: MIT"></a>
       <a href="https://github.com/JuliaDiff/BlueStyle"><img src="https://img.shields.io/badge/code%20style-blue-4495d1.svg" alt="Code Style: Blue"></a>
     </td>
@@ -77,17 +77,11 @@ The following algorithms are currently supported:
   - Saxe–Gurari–Sudborough algorithm [**under development**]
   - Brute-force search
 
-(As we remain in the early stages of development, some of these may not yet be fully implemented and/or tested. Whenever an unimplemented algorithm is used, an `ERROR: TODO: Not yet implemented` is raised.)
+(Although the API is already stable with the bulk of the library already functional and tested, a few algorithms remain under development. Whenever such an algorithm is used, the error `ERROR: TODO: Not yet implemented` is raised.)
 
 ## Installation
 
 The only prerequisite is a working Julia installation (v1.10 or later). First, enter Pkg mode by typing `]` in the Julia REPL, then run the following command:
-
-```julia-repl
-pkg> add https://github.com/Luis-Varona/MatrixBandwidth.jl
-```
-
-When *MatrixBandwidth.jl* is finally added to the official Julia registry, you will be able to install it more easily with:
 
 ```julia-repl
 pkg> add MatrixBandwidth
@@ -237,7 +231,7 @@ The latest citation information may be found in the [CITATION.bib](https://raw.g
 
 ## Project status
 
-I aim to release the first stable version of *MatrixBandwidth.jl* in late July 2025. The current version is a work-in-progress, with much of the API still under development.
+The first stable release of *MatrixBandwidth.jl*, `v0.1.0`, is now available. Although several algorithms are still under development, the bulk of the library is already functional and tested. I aim to complete development (including documentation and tests) of the remaining algorithms and other utility features by early August 2025.
 
 ## Index
 


### PR DESCRIPTION
We have decided to skip straight to releasing `v0.1.0`, as the bulk of the library is already functional and tested with remaining `TODO`'s clearly indicated and documented.

Here we edit descriptions/status in `README.md` and `docs/src/index.md` accordingly, also updating the listed version from `v0.1.0-beta` to `v0.1.0` in both of the aforementioned files plus `Project.toml`.