### PR TITLE
Edit docs+`CITATION.bib`; optimize `bandwidth`; clarify empty reducing

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,4 +1,4 @@
-@misc{Var2025,
+@misc{Var25,
   author = {Varona, Luis M. B.},
   title = {Luis-Varona/MatrixBandwidth.jl: Algorithms for matrix bandwidth minimization and recognition},
   year = {2025},

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ ERROR: TODO: Not yet implemented
 
 ## Documentation
 
-The full documentation is available at [GitHub Pages](https://luis-varona.github.io/MatrixBandwidth.jl/dev/). Documentation for methods and types is also available via the Julia REPL. To learn more about the `minimize_bandwidth` function, for instance, enter help mode by typing `?`, then run the following command:
+The full documentation is available at [GitHub Pages](https://luis-varona.github.io/MatrixBandwidth.jl/). Documentation for methods and types is also available via the Julia REPL. To learn more about the `minimize_bandwidth` function, for instance, enter help mode by typing `?`, then run the following command:
 
 ```julia-repl
 help?> minimize_bandwidth
@@ -227,4 +227,4 @@ The latest citation information may be found in the [CITATION.bib](https://raw.g
 
 ## Project status
 
-The first stable release of *MatrixBandwidth.jl*, `v0.1.0`, is now available. Although several algorithms are still under development, the bulk of the library is already functional and tested. I aim to complete development (including documentation and tests) of the remaining algorithms and other utility features by early August 2025.
+The first stable release of *MatrixBandwidth.jl*, `v0.1.0`, is now available. Although several algorithms are still under development, the bulk of the library is already functional and tested. I aim to complete development (including documentation and tests) of the remaining algorithms and other utility features by September 2025.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -193,7 +193,7 @@ ERROR: TODO: Not yet implemented
 
 ## Documentation
 
-The full documentation is available at [GitHub Pages](https://luis-varona.github.io/MatrixBandwidth.jl/dev/). Documentation for methods and types is also available via the Julia REPL—for instance, to learn more about the `minimize_bandwidth` function, enter help mode by typing `?`, then run the following command:
+The full documentation is available at [GitHub Pages](https://luis-varona.github.io/MatrixBandwidth.jl/). Documentation for methods and types is also available via the Julia REPL—for instance, to learn more about the `minimize_bandwidth` function, enter help mode by typing `?`, then run the following command:
 
 ```julia-repl
 help?> minimize_bandwidth
@@ -231,7 +231,7 @@ The latest citation information may be found in the [CITATION.bib](https://raw.g
 
 ## Project status
 
-The first stable release of *MatrixBandwidth.jl*, `v0.1.0`, is now available. Although several algorithms are still under development, the bulk of the library is already functional and tested. I aim to complete development (including documentation and tests) of the remaining algorithms and other utility features by early August 2025.
+The first stable release of *MatrixBandwidth.jl*, `v0.1.0`, is now available. Although several algorithms are still under development, the bulk of the library is already functional and tested. I aim to complete development (including documentation and tests) of the remaining algorithms and other utility features by September 2025.
 
 ## Index
 

--- a/src/MatrixBandwidth.jl
+++ b/src/MatrixBandwidth.jl
@@ -53,8 +53,8 @@ The following algorithms are currently supported:
     - Saxe–Gurari–Sudborough algorithm ([`Recognition.SaxeGurariSudborough`](@ref))
     - Brute-force search ([`Recognition.BruteForceSearch`](@ref))
 
-[Full documentation](https://Luis-Varona.github.io/MatrixBandwidth.jl/dev/) is available for
-the latest development version of this package.
+The full documentation is available at
+[GitHub Pages](https://luis-varona.github.io/MatrixBandwidth.jl/).
 """
 module MatrixBandwidth
 

--- a/src/Recognition/deciders/del_corso_manzini.jl
+++ b/src/Recognition/deciders/del_corso_manzini.jl
@@ -447,7 +447,8 @@ function _dcm_order_is_reversed(
     end
 
     #= If `unselected` is empty, then `candidate` is already the last label, not some label
-    placed at an intermediate position that we can ignore. =#
+    placed at an intermediate position that we can ignore. (Also, we avoid reducing over an
+    empty collection with `maximum` and throwing an error…) =#
     if isempty(unselected)
         max_last_label = candidate
     else

--- a/src/core.jl
+++ b/src/core.jl
@@ -82,17 +82,12 @@ function bandwidth(A::AbstractMatrix{<:Number})
         throw(RectangularMatrixError(A))
     end
 
-    #= We are only concerned with which (off-diagonal) entries are nonzero, not the actual
-    values. We also set every diagonal entry to `false` for consistency with any algorithms
-    that assume an adjacency matrix structure. =#
-    A_bool = _offdiag_nonzero_support(A)
-
-    indices = findall(A_bool)
+    indices = findall(!iszero, A)
 
     if isempty(indices)
-        band = 0
+        band = 0 # Avoid reducing over an empty collection with `maximum``
     else
-        band = maximum(abs(index[1] - index[2]) for index in indices)
+        band = maximum(Iterators.map(idx -> abs(idx[1] - idx[2]), indices))
     end
 
     return band


### PR DESCRIPTION
This PR fixes #68 by (1) replacing all instances of 'index' in source code with 'idx' for consistency and (2) avoiding reallocating `A_bool` with `_offdiag_nonzero_support` in the `bandwidth` function. It also switches the generator comprehension in `bandwidth` for an `Iterators.map` call and clarifies via inline comments why, in the case that `indices` is empty, we avoid reducing over an empty collection in `maximum`. (This same clarification is added to the source code for the Del Corso–Manzini decider in the `Recognition` submodule when the same strategy is used.)

Moreover, we make a few minor changes to the docs--`README.md`, `docs/src/index.md` (for the Documenter site), and the docstring for the `MatrixBandwidth` module. References to the Documenter site URL are made more general (instead of adding 'dev/' or 'stable/' to the end of said URLs, we just leave it as 'https://luis-varona.github.io/MatrixBandwidth.jl/', which is more idiomatic and should automatically redirect to the stable documentation anyway. In the `README` and `index`, we also change our target date for completion of core API development from 'late August 2025' to September 2025. (This does not, of course, include our goals of adding support for sparse matrices and graph formats.)

Finally, we change the BibTeX key in `CITATION.bib` from 'Var2025' to 'Var25'.