### PR TITLE
Add `profile` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Mentioned the core package exports (including the new `profile` function) in the `MatrixBandwidth` module docstring and `README.md` (#78).
+- Added the `profile` function to compute the original profile of a matrix prior to any reordering (#78).
 - Added the `homepage` field to `Project.toml` to reference the GitHub Pages documentation (#76).
 - Created `CHANGELOG.md` to document changes to this project (#72).
 - Clarified certain `if-else` checks in the `bandwidth` method and in a helper function for the Del Corso&ndash;Manzini `Recognition` deciders by explaining via inline comments that we cannot reduce over an empty collection (#71).
 
 ### Changed
 
-- Fixed the copyright preface in `docs/make.jl` (#75).
-- Updated the compatibility requirements in `test/Project.toml` to allow only a finite number of breaking releases of `Aqua` and `JET` (#74).
+- Referenced the new `profile` function in the `CuthillMcKee`, `ReverseCuthillMcKee`, and `GibbsPooleStockmeyer` docstrings when matrix profile is mentioned (#78).
+- Reformatted some entries in `docs/src/refs.bib` (some author names did not exactly match the papers) (#78).
 - Changed "*MatrixBandwidth.jl* offers several algorithms&hellip;" to "*MatrixBandwidth.jl* offers fast algorithms&hellip;" in `README.md`. Similarly changed "Luis-Varona/MatrixBandwidth.jl: Algorithms&hellip;" to "Luis-Varona/MatrixBandwidth.jl: Fast algorithms&hellip;" in `CITATION.bib` (#74).
 - Added PR numbers to changelog entries for better traceability (#73).
 - Eliminated unnecessary reallocation of a boolean matrix in the `bandwidth` method by directly using `findall(!iszero, A)` instead of calling `_offdiag_nonzero_support(A)` (#71).
@@ -23,6 +25,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Changed the GitHub Pages references in `README.md` and the `MatrixBandwidth` module docstring from the development docs to the default site URL (which redirects to the stable documentation) (#71).
 - Changed the BibTeX key in `CITATION.bib` from `Var2025` to `Var25` (#71).
 - Updated the target date for completion of core API development from mid-August 2025 to September 2025 in `README.md` (#71).
+
+### Fixed
+
+- Changed some blocks enclosed in double backticks to be enclosed in single backticks instead (meant to be rendered as code blocks, not mathematical expressions) (#78).
+- Fixed the rendering of the `dcm_ps_optimal_depth` docstring (#78).
+- Fixed the copyright preface in `docs/make.jl` (#75).
+- Updated the compatibility requirements in `test/Project.toml` to allow only a finite number of breaking releases of `Aqua` and `JET` (#74).
 
 ## [0.1.0] - 2025-07-19
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,24 @@ ERROR: TODO: Not yet implemented
 [...]
 ```
 
+Complementing our various bandwidth minimization and recognition algorithms, *MatrixBandwidth.jl* exports several additional core functions, including (but not limited to) `bandwidth` and `profile` to compute the original bandwidth and profile of a matrix prior to any reordering:
+
+```julia-repl
+julia> using Random, SparseArrays
+
+julia> Random.seed!(1234);
+
+julia> A = sprand(50, 50, 0.01); A = A + A' # Ensure structural symmetry
+
+julia> bandwidth(A) # Bandwidth prior to any reordering of rows and columns
+38
+
+julia> profile(A) # Profile prior to any reordering of rows and columns
+645
+```
+
+(Closely related to bandwidth, the *column profile* of a matrix is the sum of the distances from each diagonal entry to the farthest nonzero entry in that column, whereas the *row profile* is the sum of the distances from each diagonal entry to the farthest nonzero entry in that row. `profile(A)` computes the column profile of `A` by default, but it can also be used to compute the row profile.)
+
 ## Documentation
 
 The full documentation is available at [GitHub Pages](https://luis-varona.github.io/MatrixBandwidth.jl/). Documentation for methods and types is also available via the Julia REPL. To learn more about the `minimize_bandwidth` function, for instance, enter help mode by typing `?`, then run the following command:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -191,6 +191,24 @@ ERROR: TODO: Not yet implemented
 [...]
 ```
 
+Complementing our various bandwidth minimization and recognition algorithms, *MatrixBandwidth.jl* exports several additional core functions, including (but not limited to) `bandwidth` and `profile` to compute the original bandwidth and profile of a matrix:
+
+```julia-repl
+julia> using Random, SparseArrays
+
+julia> Random.seed!(1234);
+
+julia> A = sprand(50, 50, 0.01); A = A + A' # Ensure structural symmetry
+
+julia> bandwidth(A) # Bandwidth prior to any reordering of rows and columns
+38
+
+julia> profile(A) # Profile prior to any reordering of rows and columns
+645
+```
+
+(Closely related to bandwidth, the *column profile* of a matrix is the sum of the distances from each diagonal entry to the farthest nonzero entry in that column, whereas the *row profile* is the sum of the distances from each diagonal entry to the farthest nonzero entry in that row. `profile(A)` computes the column profile of `A` by default, but it can also be used to compute the row profile.)
+
 ## Documentation
 
 The full documentation is available at [GitHub Pages](https://luis-varona.github.io/MatrixBandwidth.jl/). Documentation for methods and types is also available via the Julia REPL—for instance, to learn more about the `minimize_bandwidth` function, enter help mode by typing `?`, then run the following command:

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -5,17 +5,17 @@
   volume = {20},
   year = {1980},
   pages = {8--14},
-  url = {https://doi.org/10.1007/BF01933580},
+  url = {https://doi.org/10.1007/BF01933580}
 }
 
 @inproceedings{CM69,
-  author = {Cuthill, Elizabeth and McKee, James},
+  author = {Cuthill, E. and McKee, J.},
   booktitle = {Proceedings of the 24th National Conference of the ACM},
   title = {Reducing the bandwidth of sparse symmetric matrices},
   year = {1969},
   pages = {157--72},
   publisher = {Brandon Systems Press},
-  url = {https://doi.org/10.1145/800195.805928},
+  url = {https://doi.org/10.1145/800195.805928}
 }
 
 @article{CSG05,
@@ -26,7 +26,7 @@
   volume = {17},
   year = {2005},
   pages = {356-73},
-  url = {https://doi.org/10.1287/ijoc.1040.0083},
+  url = {https://doi.org/10.1287/ijoc.1040.0083}
 }
 
 @article{DCM99,
@@ -36,7 +36,7 @@
   volume = {62},
   year = {1999},
   pages = {189--203},
-  url = {https://doi.org/10.1007/s006070050002},
+  url = {https://doi.org/10.1007/s006070050002}
 }
 
 @phdthesis{Geo71,
@@ -44,7 +44,7 @@
   school = {Department of Computer Science, Stanford University},
   title = {Computer Implementation of the Finite Element Method},
   year = {1971},
-  url = {https://apps.dtic.mil/sti/tr/pdf/AD0726171.pdf},
+  url = {https://apps.dtic.mil/sti/tr/pdf/AD0726171.pdf}
 }
 
 @article{GPS76,
@@ -55,7 +55,7 @@
   volume = {13},
   year = {1976},
   pages = {236--50},
-  url = {https://doi.org/10.1137/0713023},
+  url = {https://doi.org/10.1137/0713023}
 }
 
 @article{Lew82,
@@ -66,7 +66,7 @@
   volume = {8},
   year = {1982},
   pages = {180--89},
-  url = {https://doi.org/10.1145/355993.355998},
+  url = {https://doi.org/10.1145/355993.355998}
 }
 
 @misc{LLS+01,
@@ -75,7 +75,18 @@
   title = {example/cuthill_mckee_ordering.cpp},
   year = {2001},
   url = {https://www.boost.org/doc/libs/1_37_0/libs/graph/example/cuthill_mckee_ordering.cpp},
-  note = {Accessed: 2025-06-10},
+  note = {Accessed: 2025-06-10}
+}
+
+@article{Maf14,
+  author = {Mafteiu-Scai, Liviu Octavian},
+  journal = {*Annals of West University of Timisoara - Mathematics and Computer Science*},
+  number = {2},
+  title = {The Bandwidths of a Matrix. A Survey of Algorithms},
+  volume = {52},
+  year = {2014},
+  pages = {183--223},
+  url = {https://doi.org/10.2478/awutm-2014-0019}
 }
 
 @misc{Net25,
@@ -84,16 +95,16 @@
   title = {Source code for networkx.utils.rcm},
   year = {2025},
   url = {https://networkx.org/documentation/stable/_modules/networkx/utils/rcm.html},
-  note = {Accessed: 2025-06-11},
+  note = {Accessed: 2025-06-11}
 }
 
 @article{RS06,
-  author = {Reid, John K. and Scott, Jennifer A.},
+  author = {Reid, J. K. and Scott, J. A.},
   journal = {*SIAM Journal on Matrix Analysis and Applications*},
   number = {3},
   title = {Reducing the Total Bandwidth of a Sparse Unsymmetric Matrix},
   volume = {28},
   pages = {805--21},
   year = {2006},
-  url = {https://doi.org/10.1137/050629938},
+  url = {https://doi.org/10.1137/050629938}
 }

--- a/src/MatrixBandwidth.jl
+++ b/src/MatrixBandwidth.jl
@@ -53,6 +53,10 @@ The following algorithms are currently supported:
     - Saxe–Gurari–Sudborough algorithm ([`Recognition.SaxeGurariSudborough`](@ref))
     - Brute-force search ([`Recognition.BruteForceSearch`](@ref))
 
+This package also exports several additional core functions, including (but not limited to)
+[`bandwidth`](@ref) and [`profile`](@ref) to compute the original bandwidth and profile of a
+matrix prior to any reordering.
+
 The full documentation is available at
 [GitHub Pages](https://luis-varona.github.io/MatrixBandwidth.jl/).
 """
@@ -74,10 +78,13 @@ deciders `like Recognition.CapraraSalazarGonzalez`. Solvers/deciders are not exp
 top level due to name conflicts between `Minimization` and `Recognition`. =#
 export Minimization, Recognition
 
-#= Core exports: the original bandwidth (before any reordering) and an `O(n³)` lower bound
-from Caprara and Salazar-González (2005). (This bound is tight in many non-trivial cases
-but not universally so.) =#
-export bandwidth, bandwidth_lower_bound
+#= Core exports:
+- Compute the original bandwidth (before any reordering).
+- Compute Caprara and Salazar-González (2005)'s lower bound on bandwidth in `O(n³)`. (This
+    bound is tight in many non-trivial cases but not universally so.)
+- Compute the original profile (before any reordering).
+=#
+export bandwidth, bandwidth_lower_bound, profile
 
 #= `Minimization` and `Recognition` exports: the core bandwidth minimization and recognition
 functions. =#

--- a/src/Minimization/Exact/solvers/brute_force_search.jl
+++ b/src/Minimization/Exact/solvers/brute_force_search.jl
@@ -17,8 +17,8 @@ search to orderings such that ``i₁ ≤ iₙ`` (with equality checked just in c
 Given an ``n×n`` input matrix ``A``, this brute-force algorithm runs in ``O(n! ⋅ n²)`` time:
 - Precisely ``n!/2`` permutations are checked (except when ``n = 1``, in which case
     ``1! = 1`` permutation is checked). This is, clearly, ``O(n!)``.
-- For each permutation, the [`bandwidth`](@ref) function is called on
-    ``view(A, perm, perm)``, which takes ``O(n²)`` time.
+- For each permutation, the [`bandwidth`](@ref) function is called on `view(A, perm, perm)`,
+    which takes ``O(n²)`` time.
 - Therefore, the overall time complexity is ``O(n! ⋅ n²)``.
 
 Indeed, due to the need to exhaustively check all permutations, this is close to a lower

--- a/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
+++ b/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
@@ -36,9 +36,10 @@ indeed consider supporting this more performant implementation for sparse matric
 
 It was found in [Geo71; pp. 114--15](@cite) that reversing the ordering produced by
 Cuthill–McKee tends to induce a more optimal *matrix profile* (a measure of how far, on
-average, nonzero entries are from the diagonal). This so-called *reverse Cuthill–McKee*
-variant is preferred in almost all cases—see [`ReverseCuthillMcKee`](@ref) and the
-associated method of `_bool_minimal_band_ordering` for our implementation.
+average, nonzero entries are from the diagonal; see also [`MatrixBandwidth.profile`](@ref)).
+This so-called *reverse Cuthill–McKee* variant is preferred in almost all cases—see
+[`ReverseCuthillMcKee`](@ref) and the associated method of `_bool_minimal_band_ordering` for
+    our implementation.
 
 # Examples
 In the following examples, [`MatrixBandwidth.random_banded_matrix`](@ref) is used to
@@ -216,7 +217,8 @@ which induces a matrix bandwidth either equal to or very close to the true minim
 [CM69; pp. 157--58](@cite). The reverse Cuthill–McKee algorithm simply reverses the ordering
 produced by application of Cuthill–McKee; it was found in [Geo71; pp. 114--15](@cite) that
 although the bandwidth remains the same, this tends to produce a more optimal *matrix
-profile* (a measure of how far, on average, nonzero entries are from the diagonal).
+profile* (a measure of how far, on average, nonzero entries are from the diagonal; see also
+[`MatrixBandwidth.profile`](@ref)).
 
 As noted above, the reverse Cuthill–McKee algorithm requires structurally symmetric input
 (that is, ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is nonzero for

--- a/src/Minimization/Heuristic/solvers/gibbs_poole_stockmeyer.jl
+++ b/src/Minimization/Heuristic/solvers/gibbs_poole_stockmeyer.jl
@@ -24,8 +24,9 @@ an undirected graph), this implementation instead reverses the entire final orde
 every case, similarly to [`ReverseCuthillMcKee`](@ref). Conditional reversals are not only
 more complex to implement but also slightly more time-consuming, with the only benefit being
 a marginally smaller *matrix profile* (a measure of how far, on average, nonzero entries are
-from the diagonal). Since such reversal strategies do not affect matrix bandwidth (the
-primary focus of this package), we thus opt for the simpler unconditional reversal.
+from the diagonal; see also [`MatrixBandwidth.profile`](@ref)). Since such reversal
+strategies do not affect matrix bandwidth (the primary focus of this package), we opt
+instead for the simpler unconditional reversal.
 
 As noted above, the Gibbs–Poole–Stockmeyer algorithm requires structurally symmetric input
 (that is, ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is nonzero for

--- a/src/Recognition/deciders/brute_force_search.jl
+++ b/src/Recognition/deciders/brute_force_search.jl
@@ -21,8 +21,8 @@ to check subsequent permutations.
 Given an ``n×n`` input matrix ``A``, this brute-force algorithm runs in ``O(n! ⋅ n²)`` time:
 - Up to ``n!/2`` permutations may be checked (except when ``n = 1``, in which case
     ``1! = 1`` permutation is checked). This is, clearly, ``O(n!)``.
-- For each permutation, the [`bandwidth`](@ref) function is called on
-    ``view(A, perm, perm)``, which takes ``O(n²)`` time.
+- For each permutation, the [`bandwidth`](@ref) function is called on `view(A, perm, perm)`,
+    which takes ``O(n²)`` time.
 - Therefore, the overall time complexity is ``O(n! ⋅ n²)``.
 
 # Examples

--- a/src/Recognition/deciders/del_corso_manzini.jl
+++ b/src/Recognition/deciders/del_corso_manzini.jl
@@ -231,7 +231,7 @@ Base.summary(::DelCorsoManziniWithPS) = "Del Corso–Manzini with perimeter sear
 
 _requires_symmetry(::DelCorsoManziniWithPS) = true
 
-"""197 199
+"""
     dcm_ps_optimal_depth(A::AbstractMatrix{Bool}) -> Int
 
 Compute a (hopefully) near-optimal Del Corso–Manzini perimeter search depth for `A`.

--- a/test/core.jl
+++ b/test/core.jl
@@ -17,7 +17,7 @@ using SparseArrays
 using Graphs
 using Test
 
-const MAX_ORDER1 = 100
+const MAX_ORDER1 = 80
 const NUM_ITER1 = 100
 
 const MAX_ORDER2 = 8
@@ -31,6 +31,44 @@ const NUM_ITER2 = 10
         k = bandwidth(A)
 
         @test all(idx -> abs(idx[1] - idx[2]) <= k || A[idx] == 0, CartesianIndices(A))
+    end
+end
+
+@testset "`profile` (n ≤ $MAX_ORDER1)" begin
+    for n in 1:MAX_ORDER1, _ in 1:NUM_ITER1
+        density = rand()
+        A = sprand(n, n, density)
+
+        prof_default = profile(A)
+        prof_col = profile(A, dim=:col)
+        prof_row = profile(A, dim=:row)
+
+        @test prof_default == prof_col # Should compute column profile by default
+        # Only `:col` and `:row` are valid dimensions
+        @test_throws ArgumentError profile(A, dim=:nonsense)
+
+        foreach(i -> A[i, i] = 0, 1:n)
+        prof_col_zero_diag = profile(A, dim=:col)
+        prof_row_zero_diag = profile(A, dim=:row)
+
+        foreach(i -> A[i, i] = 1, 1:n)
+        prof_col_one_diag = profile(A, dim=:col)
+        prof_row_one_diag = profile(A, dim=:row)
+
+        # Diagonal entries should not affect profile
+        @test prof_col == prof_col_zero_diag == prof_col_one_diag
+        @test prof_row == prof_row_zero_diag == prof_row_one_diag
+
+        A[:, rand(1:n)] .= 0
+        A[rand(1:n), :] .= 0
+
+        # Should run even with zero rows/columns
+        @test try
+            profile(A);
+            true
+        catch
+            false
+        end
     end
 end
 


### PR DESCRIPTION
This PR adds the `profile` function to compute the original profile of a matrix prior to any reordering. It updates the CM/RCM/GPS docstrings accordingly (pointing to this new function's documentation whenever matrix profile is referenced) and elaborates in the `MatrixBandwidth` module docstring on this and bandwidth as additional core exports of the package. The `README` and Documenter index are also updated accordingly.

Some other minor changes/fixes include reformatting entries in `refs.bib`, fixing a rendering error in the `dcm_ps_optimal_depth` docstring, and fixing some code blocks enclosed in double backticks that should have been enclosed in single backticks.