### PR TITLE
Update `README`/`CHANGELOG` for `v0.1.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.1] - 2025-07-26
 
 ### Added
 
@@ -39,5 +39,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Released the initial stable version and added the package to Julia's General package registry.
 
-[unreleased]: https://github.com/Luis-Varona/MatrixBandwidth.jl/compare/v0.1.0...HEAD
+[0.1.1]: https://github.com/Luis-Varona/MatrixBandwidth.jl/releases/tag/v0.1.1
 [0.1.0]: https://github.com/Luis-Varona/MatrixBandwidth.jl/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -245,4 +245,4 @@ The latest citation information may be found in the [CITATION.bib](https://raw.g
 
 ## Project status
 
-The first stable release of *MatrixBandwidth.jl*, `v0.1.0`, is now available. Although several algorithms are still under development, the bulk of the library is already functional and tested. I aim to complete development (including documentation and tests) of the remaining algorithms and other utility features by September 2025.
+The latest stable release of *MatrixBandwidth.jl* is `v0.1.1`. Although several algorithms are still under development, the bulk of the library is already functional and tested. I aim to complete development (including documentation and tests) of the remaining algorithms and other utility features by September 2025.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -249,7 +249,7 @@ The latest citation information may be found in the [CITATION.bib](https://raw.g
 
 ## Project status
 
-The first stable release of *MatrixBandwidth.jl*, `v0.1.0`, is now available. Although several algorithms are still under development, the bulk of the library is already functional and tested. I aim to complete development (including documentation and tests) of the remaining algorithms and other utility features by September 2025.
+The latest stable release of *MatrixBandwidth.jl* is `v0.1.1`. Although several algorithms are still under development, the bulk of the library is already functional and tested. I aim to complete development (including documentation and tests) of the remaining algorithms and other utility features by September 2025.
 
 ## Index
 


### PR DESCRIPTION
This PR updates `README.md` and `CHANGELOG.md` for the pending release of `v0.1.1`. Additionally, accidentally untsgaged changes to `docs/src/index.md` from PR #78 are committed.