### PR TITLE
Change interval to set in bandwidth definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Changed the phrase `… integer k ∈ [0, n - 1] …` to `… integer k ∈ {0, 1, …, n - 1} …` every time matrix bandwidth is defined in the documentation (#84).
+
 ## [0.1.1] - 2025-07-26
 
 ### Added
@@ -39,5 +45,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Released the initial stable version and added the package to Julia's General package registry.
 
+[unreleased]: https://github.com/Luis-Varona/MatrixBandwidth.jl/compare/v0.1.1...HEAD
 [0.1.1]: https://github.com/Luis-Varona/MatrixBandwidth.jl/releases/tag/v0.1.1
 [0.1.0]: https://github.com/Luis-Varona/MatrixBandwidth.jl/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 *MatrixBandwidth.jl* offers fast algorithms for matrix bandwidth minimization and matrix bandwidth recognition.
 
-The *bandwidth* of an *n*&times;*n* matrix *A* is the minimum non-negative integer *k* &isin; [0, *n* - 1] such that *A<sub>i,j</sub>* = 0 whenever |*i* - *j*| > *k*. Equivalently, *A* has bandwidth *at most* *k* if all entries above the *k*<sup>th</sup> superdiagonal and below the *k*<sup>th</sup> subdiagonal are zero, and *A* has bandwidth *at least* *k* if there exists any nonzero entry in the *k*<sup>th</sup> superdiagonal or subdiagonal.
+The *bandwidth* of an *n*&times;*n* matrix *A* is the minimum non-negative integer *k* &isin; {0, 1, &hellip;, *n* - 1} such that *A<sub>i,j</sub>* = 0 whenever |*i* - *j*| > *k*. Equivalently, *A* has bandwidth *at most* *k* if all entries above the *k*<sup>th</sup> superdiagonal and below the *k*<sup>th</sup> subdiagonal are zero, and *A* has bandwidth *at least* *k* if there exists any nonzero entry in the *k*<sup>th</sup> superdiagonal or subdiagonal.
 
 The *matrix bandwidth minimization problem* involves finding a permutation matrix *P* such that the bandwidth of *PAP*<sup>T</sup> is minimized; this is known to be NP-complete. Several heuristic algorithms (such as Gibbs&ndash;Poole&ndash;Stockmeyer) run in polynomial time while still producing near-optimal orderings in practice, but exact methods (like Caprara&ndash;Salazar-González) are at least exponential in time complexity and thus are only feasible for relatively small matrices.
 
@@ -211,17 +211,17 @@ The full documentation is available at [GitHub Pages](https://luis-varona.github
 
 ```julia-repl
 help?> minimize_bandwidth
-search: minimize_bandwidth MatrixBandwidth bandwidth
+search: minimize_bandwidth bandwidth MatrixBandwidth
 
   minimize_bandwidth(A, solver=GibbsPooleStockmeyer()) -> MinimizationResult
 
   Minimize the bandwidth of A using the algorithm defined by solver.
 
-  The bandwidth of an n×n matrix A is the minimum non-negative integer k ∈ [0,
-  n - 1] such that A[i, j] = 0 whenever |i - j| > k. Equivalently, A has
-  bandwidth at most k if all entries above the kᵗʰ superdiagonal and below the
-  kᵗʰ subdiagonal are zero, and A has bandwidth at least k if there exists any
-  nonzero entry in the kᵗʰ superdiagonal or subdiagonal.
+  The bandwidth of an n×n matrix A is the minimum non-negative integer k ∈
+  \{0, 1, …, n - 1\} such that A[i, j] = 0 whenever |i - j| > k. Equivalently,
+  A has bandwidth at most k if all entries above the kᵗʰ superdiagonal and
+  below the kᵗʰ subdiagonal are zero, and A has bandwidth at least k if there
+  exists any nonzero entry in the kᵗʰ superdiagonal or subdiagonal.
 
   This function computes a (near-)optimal ordering π of the rows and columns
   of A so that the bandwidth of PAPᵀ is minimized, where P is the permutation
@@ -234,7 +234,7 @@ search: minimize_bandwidth MatrixBandwidth bandwidth
 
   Arguments
   ≡≡≡≡≡≡≡≡≡
-  …
+  [...]
 ```
 
 ## Citing

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -45,7 +45,7 @@ CurrentModule = MatrixBandwidth
 
 *MatrixBandwidth.jl* offers fast algorithms for matrix bandwidth minimization and matrix bandwidth recognition.
 
-The *bandwidth* of an ``n \times n`` matrix ``A`` is the minimum non-negative integer ``k \in [0, n - 1]`` such that ``A_{i,j} = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth *at most* ``k`` if all entries above the ``k^\text{th}`` superdiagonal and below the ``k^\text{th}`` subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any nonzero entry in the ``k^\text{th}`` superdiagonal or subdiagonal.
+The *bandwidth* of an ``n \times n`` matrix ``A`` is the minimum non-negative integer ``k \in \{0, 1, \ldots, n - 1\}`` such that ``A_{i,j} = 0`` whenever ``|i - j| > k``. Equivalently, ``A`` has bandwidth *at most* ``k`` if all entries above the ``k^\text{th}`` superdiagonal and below the ``k^\text{th}`` subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any nonzero entry in the ``k^\text{th}`` superdiagonal or subdiagonal.
 
 The *matrix bandwidth minimization problem* involves finding a permutation matrix ``P`` such that the bandwidth of ``PAP^\mathsf{T}`` is minimized; this is known to be NP-complete. Several heuristic algorithms (such as Gibbs–Poole–Stockmeyer) run in polynomial time while still producing near-optimal orderings in practice, but exact methods (like Caprara–Salazar-González) are at least exponential in time complexity and thus are only feasible for relatively small matrices.
 
@@ -215,17 +215,17 @@ The full documentation is available at [GitHub Pages](https://luis-varona.github
 
 ```julia-repl
 help?> minimize_bandwidth
-search: minimize_bandwidth MatrixBandwidth bandwidth
+search: minimize_bandwidth bandwidth MatrixBandwidth
 
   minimize_bandwidth(A, solver=GibbsPooleStockmeyer()) -> MinimizationResult
 
   Minimize the bandwidth of A using the algorithm defined by solver.
 
-  The bandwidth of an n×n matrix A is the minimum non-negative integer k ∈ [0,
-  n - 1] such that A[i, j] = 0 whenever |i - j| > k. Equivalently, A has
-  bandwidth at most k if all entries above the kᵗʰ superdiagonal and below the
-  kᵗʰ subdiagonal are zero, and A has bandwidth at least k if there exists any
-  nonzero entry in the kᵗʰ superdiagonal or subdiagonal.
+  The bandwidth of an n×n matrix A is the minimum non-negative integer k ∈
+  \{0, 1, …, n - 1\} such that A[i, j] = 0 whenever |i - j| > k. Equivalently,
+  A has bandwidth at most k if all entries above the kᵗʰ superdiagonal and
+  below the kᵗʰ subdiagonal are zero, and A has bandwidth at least k if there
+  exists any nonzero entry in the kᵗʰ superdiagonal or subdiagonal.
 
   This function computes a (near-)optimal ordering π of the rows and columns
   of A so that the bandwidth of PAPᵀ is minimized, where P is the permutation
@@ -238,7 +238,7 @@ search: minimize_bandwidth MatrixBandwidth bandwidth
 
   Arguments
   ≡≡≡≡≡≡≡≡≡
-  …
+  [...]
 ```
 
 ## Citing

--- a/src/MatrixBandwidth.jl
+++ b/src/MatrixBandwidth.jl
@@ -10,10 +10,10 @@
 Fast algorithms for matrix bandwidth minimization and matrix bandwidth recognition in Julia.
 
 The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
-``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
-has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ superdiagonal and below the
-``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
-nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
+``k ∈ \\{0, 1, …, n - 1\\}`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``.
+Equivalently, ``A`` has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ
+superdiagonal and below the ``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least*
+``k`` if there exists any nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
 
 The *matrix bandwidth minimization problem* involves finding a permutation matrix ``P`` such
 that the bandwidth of ``PAPᵀ`` is minimized; this is known to be NP-complete. Several

--- a/src/Minimization/Minimization.jl
+++ b/src/Minimization/Minimization.jl
@@ -10,10 +10,10 @@
 Exact, heuristic, and metaheuristic algorithms for matrix bandwidth minimization in Julia.
 
 The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
-``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
-has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ superdiagonal and below the
-``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
-nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
+``k ∈ \\{0, 1, …, n - 1\\}`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``.
+Equivalently, ``A`` has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ
+superdiagonal and below the ``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least*
+``k`` if there exists any nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
 
 The *matrix bandwidth minimization problem* involves finding a permutation matrix ``P`` such
 that the bandwidth of ``PAPᵀ`` is minimized; this is known to be NP-complete. Several

--- a/src/Minimization/core.jl
+++ b/src/Minimization/core.jl
@@ -10,10 +10,10 @@
 Minimize the bandwidth of `A` using the algorithm defined by `solver`.
 
 The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
-``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
-has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ superdiagonal and below the
-``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
-nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
+``k ∈ \\{0, 1, …, n - 1\\}`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``.
+Equivalently, ``A`` has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ
+superdiagonal and below the ``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least*
+``k`` if there exists any nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
 
 This function computes a (near-)optimal ordering ``π`` of the rows and columns of ``A`` so
 that the bandwidth of ``PAPᵀ`` is minimized, where ``P`` is the permutation matrix

--- a/src/Recognition/Recognition.jl
+++ b/src/Recognition/Recognition.jl
@@ -10,10 +10,10 @@
 Algorithms for matrix bandwidth recognition in Julia.
 
 The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
-``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
-has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ superdiagonal and below the
-``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
-nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
+``k ∈ \\{0, 1, …, n - 1\\}`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``.
+Equivalently, ``A`` has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ
+superdiagonal and below the ``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least*
+``k`` if there exists any nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
 
 The *matrix bandwidth recognition problem* entails determining whether there exists a
 permutation matrix ``P`` such that the bandwidth of ``PAPᵀ`` is at most some fixed

--- a/src/Recognition/core.jl
+++ b/src/Recognition/core.jl
@@ -10,10 +10,10 @@
 Determine whether `A` has bandwidth at most `k` using the algorithm defined by `decider`.
 
 The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
-``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
-has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ superdiagonal and below the
-``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
-nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
+``k ∈ \\{0, 1, …, n - 1\\}`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``.
+Equivalently, ``A`` has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ
+superdiagonal and below the ``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least*
+``k`` if there exists any nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
 
 Given some fixed non-negative integer `k`, this function determines (with 100% certainty)
 whether there exists some ordering ``π`` of the rows and columns of ``A`` such that the

--- a/src/core.jl
+++ b/src/core.jl
@@ -10,10 +10,10 @@
 Compute the bandwidth of `A` before any permutation of its rows and columns.
 
 The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
-``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
-has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ superdiagonal and below the
-``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
-nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
+``k ∈ \\{0, 1, …, n - 1\\}`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``.
+Equivalently, ``A`` has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ
+superdiagonal and below the ``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least*
+``k`` if there exists any nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
 
 In contrast to [`minimize_bandwidth`](@ref), this function does not attempt to minimize the
 bandwidth of `A` by permuting its rows and columns—it simply computes its bandwidth as is.
@@ -224,10 +224,10 @@ Compute a lower bound on the bandwidth of `A` using [CSG05; pp. 359--60](@cite)'
 adjacency matrices are symmetric).
 
 The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
-``k ∈ [0, n - 1]`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``. Equivalently, ``A``
-has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ superdiagonal and below the
-``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least* ``k`` if there exists any
-nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
+``k ∈ \\{0, 1, …, n - 1\\}`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``.
+Equivalently, ``A`` has bandwidth *at most* ``k`` if all entries above the ``k``ᵗʰ
+superdiagonal and below the ``k``ᵗʰ subdiagonal are zero, and ``A`` has bandwidth *at least*
+``k`` if there exists any nonzero entry in the ``k``ᵗʰ superdiagonal or subdiagonal.
 
 In contrast to [`minimize_bandwidth`](@ref), this function does not attempt to truly
 minimize the bandwidth of `A`—it simply returns a lower bound on its bandwidth up to


### PR DESCRIPTION
This PR changes 'k ∈ [0, n - 1]' to 'k ∈ {0, 1, …, n - 1}' in the definition of matrix bandwidth everywhere it is used in the source code and docs.

(Fixes #83.)