### PR TITLE
Integrate `PrecompileTools`; add `ALGORITHM` constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Started using *PrecompileTools.jl* to compile all solvers/deciders during package startup, reducing delay on first usage (formerly reached up to ~3 seconds for some algorithms) (#91).
+- Created the `MatrixBandwidth.ALGORITHMS` constant to index all available algorithms by submodule (#91).
 - Added "Supertype Hierarchy" sections to the docstrings of all subtypes (both concrete and abstract) (#90).
 - Added a section in `README.md` and the `MatrixBandwidth` module docstring covering practical applications of matrix bandwidth reduction in engineering and scientific computing (#86).
 
 ### Changed
 
+- Removed some unnecessary entries in `CHANGELOG.md` documenting super minor changes to documentation and code style (#91).
 - Changed some user-facing parameters typed as `Int` to the more generic `Integer` (#90).
-- Changed the phrase `… integer k ∈ [0, n - 1] …` to `… integer k ∈ {0, 1, …, n - 1} …` every time matrix bandwidth is defined in the documentation (#84).
 
 ## [0.1.1] - 2025-07-26
 
 ### Added
 
-- Mentioned the core package exports (including the new `profile` function) in the `MatrixBandwidth` module docstring and `README.md` (#78).
 - Added the `profile` function to compute the original profile of a matrix prior to any reordering (#78).
 - Added the `homepage` field to `Project.toml` to reference the GitHub Pages documentation (#76).
 - Created `CHANGELOG.md` to document changes to this project (#72).
@@ -28,22 +29,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- Referenced the new `profile` function in the `CuthillMcKee`, `ReverseCuthillMcKee`, and `GibbsPooleStockmeyer` docstrings when matrix profile is mentioned (#78).
-- Reformatted some entries in `docs/src/refs.bib` (some author names did not exactly match the papers) (#78).
-- Changed "*MatrixBandwidth.jl* offers several algorithms&hellip;" to "*MatrixBandwidth.jl* offers fast algorithms&hellip;" in `README.md`. Similarly changed "Luis-Varona/MatrixBandwidth.jl: Algorithms&hellip;" to "Luis-Varona/MatrixBandwidth.jl: Fast algorithms&hellip;" in `CITATION.bib` (#74).
 - Added PR numbers to changelog entries for better traceability (#73).
 - Eliminated unnecessary reallocation of a boolean matrix in the `bandwidth` method by directly using `findall(!iszero, A)` instead of calling `_offdiag_nonzero_support(A)` (#71).
 - Switched from a generator comprehension in the `bandwidth` method to `Iterators.map` (more idiomatic) (#71).
-- Changed the GitHub Pages references in `README.md` and the `MatrixBandwidth` module docstring from the development docs to the default site URL (which redirects to the stable documentation) (#71).
-- Changed the BibTeX key in `CITATION.bib` from `Var2025` to `Var25` (#71).
-- Updated the target date for completion of core API development from mid-August 2025 to September 2025 in `README.md` (#71).
 
 ### Fixed
 
 - Changed some blocks enclosed in double backticks to be enclosed in single backticks instead (meant to be rendered as code blocks, not mathematical expressions) (#78).
 - Fixed the rendering of the `dcm_ps_optimal_depth` docstring (#78).
-- Fixed the copyright preface in `docs/make.jl` (#75).
-- Updated the compatibility requirements in `test/Project.toml` to allow only a finite number of breaking releases of `Aqua` and `JET` (#74).
+- Updated the compatibility requirements in `test/Project.toml` to allow only a finite number of breaking releases of *Aqua.jl* and *JET.jl* (#74).
 
 ## [0.1.0] - 2025-07-19
 

--- a/Project.toml
+++ b/Project.toml
@@ -4,19 +4,21 @@ keywords = ["matrix bandwidth", "minimization", "sparse matrices", "scientific c
 license = "MIT"
 authors = ["Luis M. B. Varona <lm.varona@outlook.com>"]
 description = "Fast algorithms for matrix bandwidth minimization and matrix bandwidth recognition in Julia."
+homepage = "https://luis-varona.github.io/MatrixBandwidth.jl/"
 maintainers = ["Luis M. B. Varona <lm.varona@outlook.com>"]
 readme = "README.md"
 repository = "https://github.com/Luis-Varona/MatrixBandwidth.jl"
-homepage = "https://luis-varona.github.io/MatrixBandwidth.jl/"
 version = "0.1.1"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 Combinatorics = "1.0"
 DataStructures = "0.18.15"
+PrecompileTools = "1.2"
 Random = "1.10"
 julia = "1.10"

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ The following algorithms are currently supported:
 
 (Although the API is already stable with the bulk of the library already functional and tested, a few algorithms remain under development. Whenever such an algorithm is used, the error `ERROR: TODO: Not yet implemented` is raised.)
 
+An index of all available algorithms by submodule may also be accessed via the `MatrixBandwidth.ALGORITHMS` constant; simply run the following command in the Julia REPL:
+
+```julia-repl
+julia> MatrixBandwidth.ALGORITHMS
+Dict{Symbol, Union{Dict{Symbol}, Vector}} with 2 entries:
+[...]
+```
+
 ## Installation
 
 The only prerequisite is a working Julia installation (v1.10 or later). First, enter Pkg mode by typing `]` in the Julia REPL, then run the following command:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -79,6 +79,14 @@ The following algorithms are currently supported:
 
 (Although the API is already stable with the bulk of the library already functional and tested, a few algorithms remain under development. Whenever such an algorithm is used, the error `ERROR: TODO: Not yet implemented` is raised.)
 
+An index of all available algorithms by submodule may also be accessed via the `MatrixBandwidth.ALGORITHMS` constant; simply run the following command in the Julia REPL:
+
+```julia-repl
+julia> MatrixBandwidth.ALGORITHMS
+Dict{Symbol, Union{Dict{Symbol}, Vector}} with 2 entries:
+[...]
+```
+
 ## Installation
 
 The only prerequisite is a working Julia installation (v1.10 or later). First, enter Pkg mode by typing `]` in the Julia REPL, then run the following command:

--- a/src/MatrixBandwidth.jl
+++ b/src/MatrixBandwidth.jl
@@ -68,15 +68,25 @@ The full documentation is available at
 module MatrixBandwidth
 
 using Random
+using PrecompileTools: @setup_workload, @compile_workload
 
 include("utils.jl")
 include("types.jl")
 include("core.jl")
 
+"""
+    const ALGORITHMS :: Dict{Symbol, Union{Dict{Symbol}, Vector}}
+
+A dictionary indexing the data types of all available algorithms by submodule.
+"""
+const ALGORITHMS = Dict{Symbol,Union{Dict{Symbol},Vector}}()
+
 include("Recognition/Recognition.jl")
 include("Minimization/Minimization.jl")
 
 using .Minimization, .Recognition
+
+include("startup.jl")
 
 #= Module exports: allows users to call solvers like `Minimization.GibbsPooleStockmeyer` and
 deciders `like Recognition.CapraraSalazarGonzalez`. Solvers/deciders are not exported at the

--- a/src/Minimization/Exact/Exact.jl
+++ b/src/Minimization/Exact/Exact.jl
@@ -30,6 +30,7 @@ module Exact
 
 #! format: off
 import ..Recognition
+import ..ALGORITHMS
 import ..AbstractSolver
 import ..NotImplementedError, ..StructuralAsymmetryError
 import ..bandwidth, ..bandwidth_lower_bound
@@ -41,6 +42,8 @@ using Combinatorics
 
 export CapraraSalazarGonzalez,
     DelCorsoManzini, DelCorsoManziniWithPS, SaxeGurariSudborough, BruteForceSearch
+
+ALGORITHMS[:Minimization][:Exact] = []
 
 include("types.jl")
 

--- a/src/Minimization/Exact/solvers/brute_force_search.jl
+++ b/src/Minimization/Exact/solvers/brute_force_search.jl
@@ -64,6 +64,8 @@ would take over an hour.
 """
 struct BruteForceSearch <: ExactSolver end
 
+push!(ALGORITHMS[:Minimization][:Exact], BruteForceSearch)
+
 Base.summary(::BruteForceSearch) = "Brute-force search"
 
 _requires_symmetry(::BruteForceSearch) = false

--- a/src/Minimization/Exact/solvers/caprara_salazar_gonzalez.jl
+++ b/src/Minimization/Exact/solvers/caprara_salazar_gonzalez.jl
@@ -38,6 +38,8 @@ As noted above, the Caprara–Salazar-González algorithm requires structurally 
 """
 struct CapraraSalazarGonzalez <: ExactSolver end
 
+# push!(ALGORITHMS[:Minimization][:Exact], CapraraSalazarGonzalez)
+
 Base.summary(::CapraraSalazarGonzalez) = "Caprara–Salazar-González"
 
 _requires_symmetry(::CapraraSalazarGonzalez) = true

--- a/src/Minimization/Exact/solvers/del_corso_manzini.jl
+++ b/src/Minimization/Exact/solvers/del_corso_manzini.jl
@@ -124,6 +124,8 @@ algorithm," on the other hand, we implement in [`DelCorsoManziniWithPS`](@ref).
 """
 struct DelCorsoManzini <: ExactSolver end
 
+push!(ALGORITHMS[:Minimization][:Exact], DelCorsoManzini)
+
 Base.summary(::DelCorsoManzini) = "Del Corso–Manzini"
 
 _requires_symmetry(::DelCorsoManzini) = true
@@ -296,6 +298,8 @@ struct DelCorsoManziniWithPS{D<:Union{Nothing,Integer}} <: ExactSolver
         return new{Integer}(depth)
     end
 end
+
+push!(ALGORITHMS[:Minimization][:Exact], DelCorsoManziniWithPS)
 
 Base.summary(::DelCorsoManziniWithPS) = "Del Corso–Manzini with perimeter search"
 

--- a/src/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
+++ b/src/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
@@ -16,6 +16,8 @@
 """
 struct SaxeGurariSudborough <: ExactSolver end
 
+# push!(ALGORITHMS[:Minimization][:Exact], SaxeGurariSudborough)
+
 Base.summary(::SaxeGurariSudborough) = "Saxe–Gurari–Sudborough"
 
 _requires_symmetry(::SaxeGurariSudborough) = true

--- a/src/Minimization/Heuristic/Heuristic.jl
+++ b/src/Minimization/Heuristic/Heuristic.jl
@@ -29,6 +29,7 @@ This submodule is part of the `MatrixBandwidth.Minimization` submodule of the
 module Heuristic
 
 #! format: off
+import ..ALGORITHMS
 import ..AbstractSolver
 import ..NotImplementedError, ..StructuralAsymmetryError
 import .._requires_symmetry
@@ -38,6 +39,8 @@ import .._approach, .._bool_minimal_band_ordering
 using DataStructures: Queue, enqueue!, dequeue!
 
 export GibbsPooleStockmeyer, CuthillMcKee, ReverseCuthillMcKee
+
+ALGORITHMS[:Minimization][:Heuristic] = []
 
 include("utils.jl")
 include("types.jl")

--- a/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
+++ b/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
@@ -203,6 +203,8 @@ struct CuthillMcKee <: HeuristicSolver
     end
 end
 
+push!(ALGORITHMS[:Minimization][:Heuristic], CuthillMcKee)
+
 Base.summary(::CuthillMcKee) = "Cuthill–McKee"
 
 _requires_symmetry(::CuthillMcKee) = true
@@ -409,6 +411,8 @@ struct ReverseCuthillMcKee <: HeuristicSolver
         return new(node_selector)
     end
 end
+
+push!(ALGORITHMS[:Minimization][:Heuristic], ReverseCuthillMcKee)
 
 Base.summary(::ReverseCuthillMcKee) = "Reverse Cuthill–McKee"
 

--- a/src/Minimization/Heuristic/solvers/gibbs_poole_stockmeyer.jl
+++ b/src/Minimization/Heuristic/solvers/gibbs_poole_stockmeyer.jl
@@ -218,6 +218,8 @@ struct GibbsPooleStockmeyer <: HeuristicSolver
     end
 end
 
+push!(ALGORITHMS[:Minimization][:Heuristic], GibbsPooleStockmeyer)
+
 Base.summary(::GibbsPooleStockmeyer) = "Gibbs–Poole–Stockmeyer"
 
 _requires_symmetry(::GibbsPooleStockmeyer) = true

--- a/src/Minimization/Metaheuristic/Metaheuristic.jl
+++ b/src/Minimization/Metaheuristic/Metaheuristic.jl
@@ -28,6 +28,7 @@ This submodule is part of the `MatrixBandwidth.Minimization` submodule of the
 module Metaheuristic
 
 #! format: off
+import ..ALGORITHMS
 import ..AbstractSolver
 import ..NotImplementedError
 import .._requires_symmetry
@@ -35,6 +36,8 @@ import .._approach, .._bool_minimal_band_ordering
 #! format: on
 
 export SimulatedAnnealing, GeneticAlgorithm, GRASP
+
+ALGORITHMS[:Minimization][:Metaheuristic] = []
 
 include("types.jl")
 

--- a/src/Minimization/Metaheuristic/solvers/genetic_algorithm.jl
+++ b/src/Minimization/Metaheuristic/solvers/genetic_algorithm.jl
@@ -18,6 +18,8 @@ struct GeneticAlgorithm <: MetaheuristicSolver
     # TODO: Define fields and constructor (for default values)
 end
 
+# push!(ALGORITHMS[:Minimization][:Metaheuristic], GeneticAlgorithm)
+
 Base.summary(::GeneticAlgorithm) = "Genetic algorithm"
 
 _requires_symmetry(::GeneticAlgorithm) = false

--- a/src/Minimization/Metaheuristic/solvers/grasp.jl
+++ b/src/Minimization/Metaheuristic/solvers/grasp.jl
@@ -18,6 +18,8 @@ struct GRASP <: MetaheuristicSolver
     # TODO: Define fields and constructor (for default values)
 end
 
+# push!(ALGORITHMS[:Minimization][:Metaheuristic], GRASP)
+
 Base.summary(::GRASP) = "Greedy randomized adaptive search procedure (GRASP)"
 
 _requires_symmetry(::GRASP) = false

--- a/src/Minimization/Metaheuristic/solvers/simulated_annealing.jl
+++ b/src/Minimization/Metaheuristic/solvers/simulated_annealing.jl
@@ -24,6 +24,8 @@ struct SimulatedAnnealing <: MetaheuristicSolver
     # TODO: Make constructor with default values
 end
 
+# push!(ALGORITHMS[:Minimization][:Metaheuristic], SimulatedAnnealing)
+
 Base.summary(::SimulatedAnnealing) = "Simulated annealing"
 
 _requires_symmetry(::SimulatedAnnealing) = false

--- a/src/Minimization/Minimization.jl
+++ b/src/Minimization/Minimization.jl
@@ -45,12 +45,15 @@ module Minimization
 
 #! format: off
 import ..Recognition
+import ..ALGORITHMS
 import ..AbstractAlgorithm, ..AbstractResult
 import ..NotImplementedError, ..RectangularMatrixError, ..StructuralAsymmetryError
 import ..bandwidth, ..bandwidth_lower_bound
 import .._requires_symmetry, .._problem
 import .._find_direct_subtype, .._is_structurally_symmetric, .._offdiag_nonzero_support
 #! format: on
+
+ALGORITHMS[:Minimization] = Dict{Symbol,Vector}()
 
 include("types.jl")
 include("core.jl")

--- a/src/Recognition/Recognition.jl
+++ b/src/Recognition/Recognition.jl
@@ -34,6 +34,7 @@ This submodule is part of the
 module Recognition
 
 #! format: off
+import ..ALGORITHMS
 import ..AbstractAlgorithm, ..AbstractResult
 import ..NotImplementedError, ..RectangularMatrixError, ..StructuralAsymmetryError
 import ..bandwidth, ..bandwidth_lower_bound
@@ -51,6 +52,8 @@ export CapraraSalazarGonzalez, # Recognition algorithms
     DelCorsoManziniWithPS,
     SaxeGurariSudborough,
     BruteForceSearch
+
+ALGORITHMS[:Recognition] = []
 
 include("types.jl")
 include("core.jl")

--- a/src/Recognition/deciders/brute_force_search.jl
+++ b/src/Recognition/deciders/brute_force_search.jl
@@ -84,6 +84,8 @@ permutations up to reversal to ensure that the minimum bandwidth is found).
 """
 struct BruteForceSearch <: AbstractDecider end
 
+push!(ALGORITHMS[:Recognition], BruteForceSearch)
+
 Base.summary(::BruteForceSearch) = "Brute-force search"
 
 _requires_symmetry(::BruteForceSearch) = false

--- a/src/Recognition/deciders/caprara_salazar_gonzalez.jl
+++ b/src/Recognition/deciders/caprara_salazar_gonzalez.jl
@@ -41,6 +41,8 @@ said minimization algorithm in
 """
 struct CapraraSalazarGonzalez <: AbstractDecider end
 
+# push!(ALGORITHMS[:Recognition], CapraraSalazarGonzalez)
+
 Base.summary(::CapraraSalazarGonzalez) = "Caprara–Salazar-González"
 
 _requires_symmetry(::CapraraSalazarGonzalez) = true

--- a/src/Recognition/deciders/del_corso_manzini.jl
+++ b/src/Recognition/deciders/del_corso_manzini.jl
@@ -86,6 +86,8 @@ Similarly, the underlying recognition subroutine for MB-PS is implemented in
 """
 struct DelCorsoManzini <: AbstractDecider end
 
+push!(ALGORITHMS[:Recognition], DelCorsoManzini)
+
 Base.summary(::DelCorsoManzini) = "Del Corso–Manzini"
 
 _requires_symmetry(::DelCorsoManzini) = true
@@ -232,6 +234,8 @@ struct DelCorsoManziniWithPS{D<:Union{Nothing,Integer}} <: AbstractDecider
         return new{Integer}(depth)
     end
 end
+
+push!(ALGORITHMS[:Recognition], DelCorsoManziniWithPS)
 
 Base.summary(::DelCorsoManziniWithPS) = "Del Corso–Manzini with perimeter search"
 

--- a/src/Recognition/deciders/saxe_gurari_sudborough.jl
+++ b/src/Recognition/deciders/saxe_gurari_sudborough.jl
@@ -16,6 +16,8 @@
 """
 struct SaxeGurariSudborough <: AbstractDecider end
 
+# push!(ALGORITHMS[:Recognition], SaxeGurariSudborough)
+
 Base.summary(::SaxeGurariSudborough) = "Saxe–Gurari–Sudborough"
 
 function _bool_bandwidth_k_ordering(

--- a/src/startup.jl
+++ b/src/startup.jl
@@ -1,0 +1,29 @@
+# Copyright 2025 Luis M. B. Varona
+#
+# Licensed under the MIT license <LICENSE or
+# http://opensource.org/licenses/MIT>. This file may not be copied, modified, or
+# distributed except according to those terms.
+
+@setup_workload begin
+    A = BitMatrix([
+        0 0 1 1 1;
+        0 0 0 0 0;
+        1 0 0 0 0;
+        1 0 0 0 1;
+        1 0 0 1 0
+    ])
+
+    @compile_workload begin
+        bandwidth(A)
+        profile(A)
+        bandwidth_lower_bound(A)
+
+        for decider_type in ALGORITHMS[:Recognition]
+            has_bandwidth_k_ordering(A, 2, decider_type())
+        end
+
+        for solvers in values(ALGORITHMS[:Minimization]), solver_type in solvers
+            minimize_bandwidth(A, solver_type())
+        end
+    end
+end


### PR DESCRIPTION
This PR starts using _PrecompileTools.jl_ to compile all solvers/deciders during package startup, reducing delay on first usage (formerly reached up to ~3 seconds for some algorithms). It also creates the `MatrixBandwidth.ALGORITHMS` constant to index all available algorithms by submodule.

Additionally, it removes some unnecessary entries in `CHANGELOG.md` documenting super minor changes to documentation and code style.