### PR TITLE
Add References sections to docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added **References** sections to docstrings for immediate readability in the REPL and in the source code without needing to open the Documenter-generated website (#105).
+
 ## [0.1.3] - 2025-08-05
 
 ### Changed

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -18,7 +18,7 @@
   url = {https://doi.org/10.1145/800195.805928}
 }
 
-@article{CSG05,
+@article{CS05,
   author = {Caprara, Alberto and Salazar-González, Juan-José},
   journal = {*INFORMS Journal on Computing*},
   number = {3},
@@ -29,7 +29,7 @@
   url = {https://doi.org/10.1287/ijoc.1040.0083}
 }
 
-@article{DCM99,
+@article{DM99,
   author = {Del Corso, G. M. and Manzini, G.},
   journal = {*Computing*},
   title = {Finding Exact Solutions to the Bandwidth Minimization Problem},
@@ -45,6 +45,17 @@
   title = {Computer Implementation of the Finite Element Method},
   year = {1971},
   url = {https://apps.dtic.mil/sti/tr/pdf/AD0726171.pdf}
+}
+
+@article{GL79,
+  author = {George, Alan and Liu, Joseph W. H.},
+  journal = {*ACM Transactions on Mathematical Software*},
+  number = {3},
+  title = {An Implementation of a Pseudoperipheral Node Finder},
+  volume = {5},
+  year = {1979},
+  pages = {284--95},
+  url = {https://doi.org/10.1145/355841.355845}
 }
 
 @article{GPS76,

--- a/src/MatrixBandwidth.jl
+++ b/src/MatrixBandwidth.jl
@@ -12,7 +12,7 @@ Fast algorithms for matrix bandwidth minimization and matrix bandwidth recogniti
 Reordering the rows and columns of a matrix to reduce its bandwidth has many practical
 applications in engineering and scientific computing. It is a common preprocessing step used
 to improve performance when solving linear systems, approximating partial differential
-equations, optimizing circuit layout, and more [Maf14; p. 184](@cite).
+equations, optimizing circuit layout, and more [Maf14, p. 184].
 
 Recall that the *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
 ``k ∈ \\{0, 1, …, n - 1\\}`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``.
@@ -64,6 +64,12 @@ matrix prior to any reordering.
 
 The full documentation is available at
 [GitHub Pages](https://luis-varona.github.io/MatrixBandwidth.jl/).
+
+# References
+
+- [Maf14](@cite): L. O. Mafteiu-Scai. *The Bandwidths of a Matrix. A Survey of Algorithms*.
+    Annals of West University of Timisoara - Mathematics and Computer Science **52**,
+    183–223 (2014). https://doi.org/10.2478/awutm-2014-0019.
 """
 module MatrixBandwidth
 

--- a/src/Minimization/Exact/solvers/caprara_salazar_gonzalez.jl
+++ b/src/Minimization/Exact/solvers/caprara_salazar_gonzalez.jl
@@ -15,12 +15,12 @@ are pruned not only by ensuring that adjacent pairs of currently placed indices 
 ``k`` of each other but also by employing a branch-and-bound framework with lower bounds on
 bandwidtth compatibility computed via integer linear programming relaxations. This search is
 repeated with incrementing values of ``k`` until a bandwidth-``k`` ordering is found
-[CSG05](@cite), with ``k`` initialized to some lower bound on the minimum bandwidth of ``A``
-up to symmetric permutation.
+[CS05], with ``k`` initialized to some lower bound on the minimum bandwidth of ``A`` up to
+symmetric permutation.
 
 Specifically, this implementation of the Caprara–Salazar-González algorithm uses the
-``min(α(A), γ(A))`` lower bound from the original paper [CSG05; pp. 359--60](@cite) as the
-initial value of ``k``. (Further implementation details can be found in the source code for
+``min(α(A), γ(A))`` lower bound from the original paper [CS05, pp. 359--60] as the initial
+value of ``k``. (Further implementation details can be found in the source code for
 [`bandwidth_lower_bound`](@ref).)
 
 As noted above, the Caprara–Salazar-González algorithm requires structurally symmetric input
@@ -35,6 +35,12 @@ As noted above, the Caprara–Salazar-González algorithm requires structurally 
 
 # Examples
 [TODO: Write here]
+
+# References
+
+- [CS05](@cite): A. Caprara and J.-J. Salazar-González. *Laying Out Sparse Graphs with
+    Provably Minimum Bandwidth*. INFORMS Journal on Computing **17**, 356–73 (2005).
+    https://doi.org/10.1287/ijoc.1040.0083.
 """
 struct CapraraSalazarGonzalez <: ExactSolver end
 

--- a/src/Minimization/Exact/solvers/del_corso_manzini.jl
+++ b/src/Minimization/Exact/solvers/del_corso_manzini.jl
@@ -14,15 +14,15 @@ adding indices one at a time. Partial orderings are pruned not only by ensuring 
 adjacent pairs of currently placed indices are within ``k`` of each other but also by
 tracking the latest positions at which the remaining indices can be placed. This search is
 repeated with incrementing values of ``k`` until a bandwidth-``k`` ordering is found
-[DCM99](@cite), with ``k`` initialized to some lower bound on the minimum bandwidth of ``A``
-up to symmetric permutation.
+[DM99], with ``k`` initialized to some lower bound on the minimum bandwidth of ``A`` up to
+symmetric permutation.
 
 Specifically, this implementation of the Del Corso–Manzini algorithm uses the
-``min(α(A), γ(A))`` lower bound from [CSG05; pp. 359--60](@cite) as the initial value of
-``k``. (Further implementation details can be found in the source code for
+``min(α(A), γ(A))`` lower bound from [CS05, pp. 359--60] as the initial value of ``k``.
+(Further implementation details can be found in the source code for
 [`bandwidth_lower_bound`](@ref).) This improves upon the original algorithm, which used the
 maximum number of nonzero off-diagonal entries in a single row as a lower bound on the
-minimum bandwidth of ``A`` up to symmetric permutation [DCM99; p. 192--93](@cite).
+minimum bandwidth of ``A`` up to symmetric permutation [DM99, p. 192--93].
 
 As noted above, the Del Corso–Manzini algorithm requires structurally symmetric input (that
 is, ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is nonzero for ``1 ≤ i, j ≤ n``).
@@ -44,9 +44,9 @@ Given an ``n×n`` input matrix ``A``, the Del Corso–Manzini algorithm runs in
 
 Of course, this is but an upper bound on the time complexity of Del Corso–Manzini, achieved
 only in the most pathological of cases. In practice, efficient pruning techniques and
-compatibility checks—along with [CSG05; pp. 359--60](@cite)'s relatively tight initial lower
-bound on the minimum bandwidth—result in approximately exponential growth in time complexity
-with respect to ``n``.
+compatibility checks—along with [CS05, pp. 359--60]'s relatively tight initial lower bound
+on the minimum bandwidth—result in approximately exponential growth in time complexity with
+respect to ``n``.
 
 Based on experimental results, the algorithm is feasible for ``n×n`` matrices up to
 ``n ≈ 100`` or so.
@@ -88,7 +88,7 @@ bandwidth-``10`` ordering, which is (we claim) optimal up to symmetric permutati
 cases, `random_banded_matrix(n, k)` *does* generate matrices with minimum bandwidth `< k`.
 Nevertheless, this example demonstrates that Del Corso–Manzini at the very least finds a
 good ordering, even though exact optimality—which *is* guaranteed by the original paper
-[DCM99](@cite)—is not explicitly verified.)
+[DM99]—is not explicitly verified.)
 ```jldoctest
 julia> using Random
 
@@ -119,8 +119,17 @@ Results of Bandwidth Minimization Algorithm
 
 # Notes
 For readers of the original paper, what we call the Del Corso–Manzini minimization algorithm
-here is designated the "MB-ID algorithm" in [DCM99; p. 191](@cite). The so-called "MB-PS
-algorithm," on the other hand, we implement in [`DelCorsoManziniWithPS`](@ref).
+here is designated the "MB-ID algorithm" in [DM99, p. 191]. The so-called "MB-PS algorithm,"
+on the other hand, we implement in [`DelCorsoManziniWithPS`](@ref).
+
+# References
+
+- [CS05](@cite): A. Caprara and J.-J. Salazar-González. *Laying Out Sparse Graphs with
+    Provably Minimum Bandwidth*. INFORMS Journal on Computing **17**, 356–73 (2005).
+    https://doi.org/10.1287/ijoc.1040.0083.
+- [DM99](@cite): G. M. Del Corso and G. Manzini. *Finding Exact Solutions to the Bandwidth
+    Minimization Problem*. Computing **62**, 189–203 (1999).
+    https://doi.org/10.1007/s006070050002.
 """
 struct DelCorsoManzini <: ExactSolver end
 
@@ -140,8 +149,8 @@ and columns of ``A`` for some fixed ``k ∈ ℕ``, adding indices one at a time.
 orderings are pruned not only by ensuring that adjacent pairs of currently placed indices
 are within ``k`` of each other but also by tracking the latest positions at which the
 remaining indices can be placed. This search is repeated with incrementing values of ``k``
-until a bandwidth-``k`` ordering is found [DCM99](@cite), with ``k`` initialized to some
-lower bound on the minimum bandwidth of ``A`` up to symmetric permutation.
+until a bandwidth-``k`` ordering is found [DM99], with ``k`` initialized to some lower bound
+on the minimum bandwidth of ``A`` up to symmetric permutation.
 
 The incorporation of perimeter search to this approach entails precomputing a "perimeter" of
 ``d``-permutations of row indices of ``A``, where ``d`` is a positive integer passed as a
@@ -155,11 +164,11 @@ selected.
 
 Like our implementation of the base Del Corso–Manzini algorithm (see
 [`DelCorsoManzini`](@ref)), this implementation uses the ``min(α(A), γ(A))`` lower bound
-from [CSG05; pp. 359--60](@cite) as the initial value of ``k``. (Further implementation
-details can be found in the source code for [`bandwidth_lower_bound`](@ref).) This improves
-upon the original algorithm, which used the maximum number of nonzero off-diagonal entries
-in a single row as a lower bound on the minimum bandwidth of ``A`` up to symmetric
-permutation [DCM99; p. 194](@cite).
+from [CS05, pp. 359--60] as the initial value of ``k``. (Further implementation details can
+be found in the source code for [`bandwidth_lower_bound`](@ref).) This improves upon the
+original algorithm, which used the maximum number of nonzero off-diagonal entries in a
+single row as a lower bound on the minimum bandwidth of ``A`` up to symmetric permutation
+[DM99, p. 194].
 
 As noted above, the Del Corso–Manzini algorithm with perimeter search requires structurally
 symmetric input (that is, ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is
@@ -197,9 +206,9 @@ algorithm with perimeter search runs in ``O(n! ⋅ nᴰ⁺¹)`` time, where ``D�
 
 Of course, this is but an upper bound on the time complexity of Del Corso–Manzini with
 perimeter search, achieved only in the most pathological of cases. In practice, efficient
-pruning techniques and compatibility checks—along with [CSG05; pp. 359--60](@cite)'s
-relatively tight initial lower bound on the minimum bandwidth—result in approximately
-exponential growth in time complexity with respect to ``n``.
+pruning techniques and compatibility checks—along with [CS05, pp. 359--60]'s relatively
+tight initial lower bound on the minimum bandwidth—result in approximately exponential
+growth in time complexity with respect to ``n``.
 
 Based on experimental results, the algorithm is feasible for ``n×n`` matrices up to
 ``n ≈ 100`` or so.
@@ -244,8 +253,8 @@ finds a bandwidth-``8`` ordering, which is (we claim) optimal up to symmetric pe
 (In some cases, `random_banded_matrix(n, k)` *does* generate matrices with minimum bandwidth
 `< k`. Nevertheless, this example demonstrates that Del Corso–Manzini at the very least
 finds a good ordering, even though exact optimality—which *is* guaranteed by the original
-paper [DCM99](@cite)—is not explicitly verified.) In this case, we set the depth parameter
-to ``4`` beforehand instead of relying on [`Recognition.dcm_ps_optimal_depth`](@ref).
+paper [DM99]—is not explicitly verified.) In this case, we set the depth parameter to ``4``
+beforehand instead of relying on [`Recognition.dcm_ps_optimal_depth`](@ref).
 
 ```jldoctest
 julia> using Random
@@ -277,9 +286,17 @@ Results of Bandwidth Minimization Algorithm
 
 # Notes
 For readers of the original paper, what we call the Del Corso–Manzini minimization algorithm
-with perimeter search here is designated the "MB-PS algorithm" in [DCM99; p. 193](@cite).
-The so-called "MB-ID algorithm," on the other hand, we implement in
-[`DelCorsoManzini`](@ref).
+with perimeter search here is designated the "MB-PS algorithm" in [DM99. p. 193]. The
+so-called "MB-ID algorithm," on the other hand, we implement in [`DelCorsoManzini`](@ref).
+
+# References
+
+- [CS05](@cite): A. Caprara and J.-J. Salazar-González. *Laying Out Sparse Graphs with
+    Provably Minimum Bandwidth*. INFORMS Journal on Computing **17**, 356–73 (2005).
+    https://doi.org/10.1287/ijoc.1040.0083.
+- [DM99](@cite): G. M. Del Corso and G. Manzini. *Finding Exact Solutions to the Bandwidth
+    Minimization Problem*. Computing **62**, 189–203 (1999).
+    https://doi.org/10.1007/s006070050002.
 """
 struct DelCorsoManziniWithPS{D<:Union{Nothing,Integer}} <: ExactSolver
     depth::D

--- a/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
+++ b/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
@@ -13,7 +13,7 @@ is ``A`` (ignoring weights and self-loops) and performs a breadth-first search o
 connected component of ``G(A)``, starting from a low-degree node then visiting its neighbors
 in order of increasing degree. Particularly effective when ``A`` is sparse, this heuristic
 typically produces an ordering which induces a matrix bandwidth either equal to or very
-close to the true minimum [CM69; pp. 157--58](@cite).
+close to the true minimum [CM69, pp. 157--58].
 
 As noted above, the Cuthill–McKee algorithm requires structurally symmetric input (that is,
 ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is nonzero for ``1 ≤ i, j ≤ n``).
@@ -30,19 +30,19 @@ As noted above, the Cuthill–McKee algorithm requires structurally symmetric in
 # Performance
 Given an ``n×n`` input matrix ``A``, the Cuthill–McKee algorithm runs in ``O(n²)`` time.
 
-[CG80](@cite) provide a linear-time implementation in the number of nonzero entries of
-``A``, which is still quadratic when ``A`` is dense but often much faster when dealing with
-sparse matrices. However, this would require that ``A`` be stored as a graph or a sparse
-matrix, which runs counter to our desire to provide a bandwidth minimization API for all
+[CG80] provide a linear-time implementation in the number of nonzero entries of ``A``, which
+is still quadratic when ``A`` is dense but often much faster when dealing with sparse
+matrices. However, this would require that ``A`` be stored as a graph or a sparse matrix,
+which runs counter to our desire to provide a bandwidth minimization API for all
 `AbstractMatrix{<:Number}` types, including dense matrices. (In the future, however, we may
 indeed consider supporting this more performant implementation for sparse matrices.)
 
-It was found in [Geo71; pp. 114--15](@cite) that reversing the ordering produced by
-Cuthill–McKee tends to induce a more optimal *matrix profile* (a measure of how far, on
-average, nonzero entries are from the diagonal; see also [`MatrixBandwidth.profile`](@ref)).
-This so-called *reverse Cuthill–McKee* variant is preferred in almost all cases—see
+It was found in [Geo71, pp. 114--15] that reversing the ordering produced by Cuthill–McKee
+tends to induce a more optimal *matrix profile* (a measure of how far, on average, nonzero
+entries are from the diagonal; see also [`MatrixBandwidth.profile`](@ref)). This so-called
+*reverse Cuthill–McKee* variant is preferred in almost all cases—see
 [`ReverseCuthillMcKee`](@ref) and the associated method of `_bool_minimal_band_ordering` for
-    our implementation.
+our implementation.
 
 # Examples
 In the following examples, [`MatrixBandwidth.random_banded_matrix`](@ref) is used to
@@ -193,6 +193,18 @@ Results of Bandwidth Minimization Algorithm
 Note that the `node_selector` field must be of the form
 `(A::AbstractMatrix{Bool}) -> Integer` (i.e., it must take in an boolean matrix and return
 an integer). If this is not the case, an `ArgumentError` is thrown upon construction.
+
+# References
+
+- [CG80](@cite): W. M. Chan and A. George. *A linear time implementation of the reverse
+    Cuthill–McKee algorithm*. BIT Numerical Mathematics **20**, 8–14 (1980).
+    https://doi.org/10.1007/BF01933580.
+- [CM69](@cite): E. Cuthill and J. McKee. *Reducing the bandwidth of sparse symmetric
+    matrices*. In: *Proceedings of the 24th National Conference of the ACM* (Brandon Systems
+    Press, 1969); pp. 157–72. https://doi.org/10.1145/800195.805928.
+- [Geo71](@cite): J. A. George. *Computer Implementation of the Finite Element Method*.
+    Ph.D. Thesis, Department of Computer Science, Stanford University (1971).
+    https://apps.dtic.mil/sti/tr/pdf/AD0726171.pdf.
 """
 struct CuthillMcKee <: HeuristicSolver
     node_selector::Function
@@ -219,10 +231,10 @@ and self-loops) and performs a breadth-first search of each connected component 
 starting from a low-degree node then visiting its neighbors in order of increasing degree.
 Particularly effective when ``A`` is sparse, this heuristic typically produces an ordering
 which induces a matrix bandwidth either equal to or very close to the true minimum
-[CM69; pp. 157--58](@cite). The reverse Cuthill–McKee algorithm simply reverses the ordering
-produced by application of Cuthill–McKee; it was found in [Geo71; pp. 114--15](@cite) that
-although the bandwidth remains the same, this tends to produce a more optimal *matrix
-profile* (a measure of how far, on average, nonzero entries are from the diagonal; see also
+[CM69, pp. 157--58]. The reverse Cuthill–McKee algorithm simply reverses the ordering
+produced by application of Cuthill–McKee; it was found in [Geo71, pp. 114--15] that although
+the bandwidth remains the same, this tends to produce a more optimal *matrix profile* (a
+measure of how far, on average, nonzero entries are from the diagonal; see also
 [`MatrixBandwidth.profile`](@ref)).
 
 As noted above, the reverse Cuthill–McKee algorithm requires structurally symmetric input
@@ -233,10 +245,10 @@ As noted above, the reverse Cuthill–McKee algorithm requires structurally symm
 Given an ``n×n`` input matrix ``A``, the reverse Cuthill–McKee algorithm runs in ``O(n²)``
 time.
 
-[CG80](@cite) provide a linear-time implementation in the number of nonzero entries of
-``A``, which is still quadratic when ``A`` is dense but often much faster when dealing with
-sparse matrices. However, this would require that ``A`` be stored as a graph or a sparse
-matrix, which runs counter to our desire to provide a bandwidth minimization API for all
+[CG80] provide a linear-time implementation in the number of nonzero entries of ``A``, which
+is still quadratic when ``A`` is dense but often much faster when dealing with sparse
+matrices. However, this would require that ``A`` be stored as a graph or a sparse matrix,
+which runs counter to our desire to provide a bandwidth minimization API for all
 `AbstractMatrix{<:Number}` types, including dense matrices. (In the future, however, we may
 indeed consider supporting this more performant implementation for sparse matrices.)
 
@@ -402,6 +414,18 @@ an integer). If this is not the case, an `ArgumentError` is thrown upon construc
 See also the documentation for [`CuthillMcKee`](@ref)—the original (non-reversed) algorithm.
 (Indeed, the reverse Cuthill–McKee method of `_bool_minimal_band_ordering` is merely a
 wrapper around the Cuthill–McKee method.)
+
+# References
+
+- [CG80](@cite): W. M. Chan and A. George. *A linear time implementation of the reverse
+    Cuthill–McKee algorithm*. BIT Numerical Mathematics **20**, 8–14 (1980).
+    https://doi.org/10.1007/BF01933580.
+- [CM69](@cite): E. Cuthill and J. McKee. *Reducing the bandwidth of sparse symmetric
+    matrices*. In: *Proceedings of the 24th National Conference of the ACM* (Brandon Systems
+    Press, 1969); pp. 157–72. https://doi.org/10.1145/800195.805928.
+- [Geo71](@cite): J. A. George. *Computer Implementation of the Finite Element Method*.
+    Ph.D. Thesis, Department of Computer Science, Stanford University (1971).
+    https://apps.dtic.mil/sti/tr/pdf/AD0726171.pdf.
 """
 struct ReverseCuthillMcKee <: HeuristicSolver
     node_selector::Function

--- a/src/Minimization/Heuristic/solvers/gibbs_poole_stockmeyer.jl
+++ b/src/Minimization/Heuristic/solvers/gibbs_poole_stockmeyer.jl
@@ -13,17 +13,17 @@ matrix is ``A`` (ignoring weights and self-loops) and builds an ordering by iden
 pair of "endpoints" in the graph far from each other, constructing sets of levels from
 these endpoints, and merging these level structures in such a way that minimizes the size of
 the largest level in the final combined structure. Based on the classical reverse
-Cuthill–McKee algorithm [Geo71](@cite), this heuristic typically produces an ordering which
-induces a matrix bandwidth either equal to or very close to the true minimum, with
-improvements in bandwidths over reverse Cuthill–McKee more noticeable once input size
-exceeds ``400×400`` or so [GPS76; pp. 246--47](@cite).
+Cuthill–McKee algorithm [Geo71], this heuristic typically produces an ordering which induces
+a matrix bandwidth either equal to or very close to the true minimum, with improvements in
+bandwidths over reverse Cuthill–McKee more noticeable once input size exceeds ``400×400`` or
+so [GPS76, pp. 246--47].
 
 Whereas the original paper outlined a strategy for conditionally reversing the orderings of
-individual "connected components" [GPS76; p. 241](@cite) (treating the input matrix ``A`` as
-an undirected graph), this implementation instead reverses the entire final ordering in
-every case, similarly to [`ReverseCuthillMcKee`](@ref). Conditional reversals are not only
-more complex to implement but also slightly more time-consuming, with the only benefit being
-a marginally smaller *matrix profile* (a measure of how far, on average, nonzero entries are
+individual "connected components" (treating the input matrix ``A`` as an undirected graph)
+[GPS76, p. 241], this implementation instead reverses the entire final ordering in every
+case, similarly to [`ReverseCuthillMcKee`](@ref). Conditional reversals are not only more
+complex to implement but also slightly more time-consuming, with the only benefit being a
+marginally smaller *matrix profile* (a measure of how far, on average, nonzero entries are
 from the diagonal; see also [`MatrixBandwidth.profile`](@ref)). Since such reversal
 strategies do not affect matrix bandwidth (the primary focus of this package), we opt
 instead for the simpler unconditional reversal.
@@ -45,16 +45,16 @@ As noted above, the Gibbs–Poole–Stockmeyer algorithm requires structurally s
 Given an ``n×n`` input matrix ``A``, the Gibbs–Poole–Stockmeyer algorithm runs in ``O(n²)``
 time.
 
-[Lew82](@cite) provides a notably faster and more memory-efficient implementation, relying
-on sparse storage of the input matrix. However, this would run counter to our desire to
-provide a bandwidth minimization API for all `AbstractMatrix{<:Number}` types, including
-dense matrices. (In the future, however, we may indeed consider supporting this more
-performant implementation for sparse matrices.)
+[Lew82] provides a notably faster and more memory-efficient implementation, relying on
+sparse storage of the input matrix. However, this would run counter to our desire to provide
+a bandwidth minimization API for all `AbstractMatrix{<:Number}` types, including dense
+matrices. (In the future, however, we may indeed consider supporting this more performant
+implementation for sparse matrices.)
 
 On that note, Gibbs–Poole–Stockmeyer has been found to take considerably less time than
-reverse Cuthill–McKee when matrices are stored in sparse format [GPS76; pp. 246--47](@cite).
-The dense-matrix implementations of both algorithms in this package, however, result in
-reverse Cuthill–McKee consistently outperforming Gibbs–Poole–Stockmeyer in terms of runtime
+reverse Cuthill–McKee when matrices are stored in sparse format [GPS76, pp. 246--47]. The
+dense-matrix implementations of both algorithms in this package, however, result in reverse
+Cuthill–McKee consistently outperforming Gibbs–Poole–Stockmeyer in terms of runtime
 (although Gibbs–Poole–Stockmeyer still typically produces lower-bandwidth orderings for
 larger matrices). This further motivates the desire to implement a sparse version of both
 algorithms in the future.
@@ -208,6 +208,18 @@ Results of Bandwidth Minimization Algorithm
 Note that the `node_selector` field must be of the form
 `(A::AbstractMatrix{Bool}) -> Integer` (i.e., it must take in an boolean matrix and return
 an integer). If this is not the case, an `ArgumentError` is thrown upon construction.
+
+# References
+
+- [Geo71](@cite): J. A. George. *Computer Implementation of the Finite Element Method*.
+    Ph.D. Thesis, Department of Computer Science, Stanford University (1971).
+    https://apps.dtic.mil/sti/tr/pdf/AD0726171.pdf.
+- [GPS76](@cite): N. E. Gibbs, W. G. Poole Jr. and P. K. Stockmeyer. *An Algorithm for
+    Reducing the Bandwidth and Profile of a Sparse Matrix*. SIAM Journal on Numerical
+    Analysis **13**, 236–50 (1976). https://doi.org/10.1137/0713023.
+- [Lew82](@cite): J. G. Lewis. *Implementation of the Gibbs–Poole–Stockmeyer and Gibbs–King
+    Algorithms*. ACM Transactions on Mathematical Software **8**, 180–89 (1982).
+    https://doi.org/10.1145/355993.355998.
 """
 struct GibbsPooleStockmeyer <: HeuristicSolver
     node_selector::Function

--- a/src/Minimization/Heuristic/utils.jl
+++ b/src/Minimization/Heuristic/utils.jl
@@ -25,12 +25,20 @@ otherwise, undefined behavior may arise.
 - `Int`: the index of the pseudo-peripheral node selected from the graph.
 
 # Notes
-This function takes heavy inspiration from the implementation in [Net25](@cite), which
-accepts a graph object as input and leverages several pre-existing functions in the
-`networkx` library. We herein repurpose the logic to work directly on adjacency matrices,
-avoiding reallocation overhead and an unnecessary dependency on `Graphs.jl`.
+This function takes heavy inspiration from the implementation in [Net25], which in turn is
+based on the algorithm described in [GL79]. Whereas the [Net25] implementation accepts a
+graph object as input and leverages several pre-existing functions in the networkx library,
+we repurpose the logic to work directly on adjacency matrices, avoiding reallocation
+overhead and an unnecessary dependency on the *Graphs.jl* package.
 
-[TODO: Specify the actual academic source for this, not just the NetworkX one.]
+# References
+
+- [GL79](@cite): A. George and J. W. Liu. *An Implementation of a Pseudoperipheral Node
+    Finder*. ACM Transactions on Mathematical Software **5**, 284–95 (1979).
+    https://doi.org/10.1145/355841.355845.
+- [Net25](@cite): NetworkX Developers. *Source code for networkx.utils.rcm*. NetworkX v3.5
+    documentation (2025). Accessed: 2025-06-11.
+    https://networkx.org/documentation/stable/_modules/networkx/utils/rcm.html.
 """
 function pseudo_peripheral_node(A::AbstractMatrix{Bool})
     n = size(A, 1)

--- a/src/Minimization/types.jl
+++ b/src/Minimization/types.jl
@@ -73,7 +73,7 @@ struct MinimizationResult{A<:AbstractSolver,M<:AbstractMatrix{<:Number},O<:Vecto
     end
 end
 
-# The `Base.show` override here takes heavy inspiration from the `Optim.jl` package
+# The `Base.show` override here takes heavy inspiration from the Optim.jl package
 function Base.show(io::IO, res::MinimizationResult)
     n = size(res.matrix, 1)
 

--- a/src/Recognition/deciders/caprara_salazar_gonzalez.jl
+++ b/src/Recognition/deciders/caprara_salazar_gonzalez.jl
@@ -15,8 +15,8 @@ the left and right ends. Partial orderings are pruned not only by ensuring that 
 pairs of currently placed indices are within ``k`` of each other but also by employing a
 branch-and-bound framework with lower bounds on bandwidtth compatibility computed via
 integer linear programming relaxations. This search is repeated with incrementing values of
-``k`` until a bandwidth-``k`` ordering is found [CSG05](@cite), with ``k`` initialized to
-some lower bound on the minimum bandwidth of ``A`` up to symmetric permutation.
+``k`` until a bandwidth-``k`` ordering is found [CS05], with ``k`` initialized to some lower
+bound on the minimum bandwidth of ``A`` up to symmetric permutation.
 
 As noted above, the Caprara–Salazar-González algorithm requires structurally symmetric input
 (that is, ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is nonzero for
@@ -32,12 +32,18 @@ As noted above, the Caprara–Salazar-González algorithm requires structurally 
 [TODO: Write here]
 
 # Notes
-This algorithm is not the main one described in the original paper [CSG05](@cite), which
-actually never explicitly presents a procedure for matrix bandwidth recognition. However,
-the paper does define a bandwidth minimization algorithm that repeatedly calls a recognition
+This algorithm is not the main one described in the original paper, which actually never
+explicitly presents a procedure for matrix bandwidth recognition [CS05]. However, the paper
+does define a bandwidth minimization algorithm that repeatedly calls a recognition
 subroutine—this is precisely the logic we implement here. (We do, however, also implement
 said minimization algorithm in
 [`MatrixBandwidth.Minimization.Exact.CapraraSalazarGonzalez`](@ref).)
+
+# References
+
+- [CS05](@cite): A. Caprara and J.-J. Salazar-González. *Laying Out Sparse Graphs with
+    Provably Minimum Bandwidth*. INFORMS Journal on Computing **17**, 356–73 (2005).
+    https://doi.org/10.1287/ijoc.1040.0083.
 """
 struct CapraraSalazarGonzalez <: AbstractDecider end
 

--- a/src/Recognition/deciders/del_corso_manzini.jl
+++ b/src/Recognition/deciders/del_corso_manzini.jl
@@ -13,7 +13,7 @@ symmetric permutation. The algorithm performs a depth-first search of all partia
 of the rows and columns of ``A``, adding indices one at a time. Partial orderings are pruned
 not only by ensuring that adjacent pairs of currently placed indices are within ``k`` of
 each other but also by tracking the latest positions at which the remaining indices can be
-placed [DCM99](@cite).
+placed [DM99].
 
 As noted above, the Del Corso–Manzini algorithm requires structurally symmetric input (that
 is, ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is nonzero for ``1 ≤ i, j ≤ n``).
@@ -72,17 +72,23 @@ Results of Bandwidth Recognition Algorithm
 # Notes
 For readers of the original paper, what we call the Del Corso–Manzini recognition algorithm
 here is essentially a wrapper around the underlying `AddNode` subroutine in what
-[DCM99; p. 191](@cite) terms the "MB-ID algorithm" for bandwidth minimization (not mere
-recognition). MB-ID (which we also implement in
+[DM99, p. 191] term the "MB-ID algorithm" for bandwidth minimization (not mere recognition).
+MB-ID (which we also implement in
 [`MatrixBandwidth.Minimization.Exact.DelCorsoManzini`](@ref)) calls this recognition
 procedure with incrementing values of ``k`` until a bandwidth-``k`` ordering is found, with
 ``k`` initialized to some lower bound on the minimum bandwidth of ``A`` up to symmetric
 permutation.
 
-[DCM99; p. 193](@cite) also describes an "MB-PS algorithm" for bandwidth minimization,
-which we implement in [`MatrixBandwidth.Minimization.Exact.DelCorsoManziniWithPS`](@ref).
-Similarly, the underlying recognition subroutine for MB-PS is implemented in
+[DM99, p. 193] also describe an "MB-PS algorithm" for bandwidth minimization, which we
+implement in [`MatrixBandwidth.Minimization.Exact.DelCorsoManziniWithPS`](@ref). Similarly,
+the underlying recognition subroutine for MB-PS is implemented in
 [`DelCorsoManziniWithPS`](@ref).
+
+# References
+
+- [DM99](@cite): G. M. Del Corso and G. Manzini. *Finding Exact Solutions to the Bandwidth
+    Minimization Problem*. Computing **62**, 189–203 (1999).
+    https://doi.org/10.1007/s006070050002.
 """
 struct DelCorsoManzini <: AbstractDecider end
 
@@ -101,7 +107,7 @@ bandwidth at most ``k`` up to symmetric permutation. The base Del Corso–Manzin
 performs a depth-first search of all partial orderings of the rows and columns of ``A``,
 adding indices one at a time. Partial orderings are pruned not only by ensuring that
 adjacent pairs of currently placed indices are within ``k`` of each other but also by
-tracking the latest positions at which the remaining indices can be placed [DCM99](@cite).
+tracking the latest positions at which the remaining indices can be placed [DM99].
 
 The incorporation of perimeter search to this approach entails precomputing a "perimeter" of
 ``d``-permutations of row indices of ``A``, where ``d`` is a positive integer passed as a
@@ -206,16 +212,22 @@ Results of Bandwidth Recognition Algorithm
 # Notes
 For readers of the original paper, what we call the Del Corso–Manzini recognition algorithm
 with perimeter search here is essentially a wrapper around the underlying `AddNode1` and
-`Prune` subroutines in what [DCM99; p. 193](@cite) terms the "MB-PS algorithm" for bandwidth
+`Prune` subroutines in what [DM99, p. 193] term the "MB-PS algorithm" for bandwidth
 minimization (not mere recognition). MB-PS (which we also implement in
 [`MatrixBandwidth.Minimization.Exact.DelCorsoManziniWithPS`](@ref)) calls this recognition
 procedure with incrementing values of ``k`` until a bandwidth-``k`` ordering is found, with
 ``k`` initialized to some lower bound on the minimum bandwidth of ``A`` up to symmetric
 permutation.
 
-[DCM99; p. 191](@cite) also describes an "MB-ID algorithm" for bandwidth minimization, which
-we implement in [`MatrixBandwidth.Minimization.Exact.DelCorsoManzini`](@ref). Similarly, the
+[DM99, p. 191] also describe an "MB-ID algorithm" for bandwidth minimization, which we
+implement in [`MatrixBandwidth.Minimization.Exact.DelCorsoManzini`](@ref). Similarly, the
 underlying recognition subroutine for MB-ID is implemented in [`DelCorsoManzini`](@ref).
+
+# References
+
+- [DM99](@cite): G. M. Del Corso and G. Manzini. *Finding Exact Solutions to the Bandwidth
+    Minimization Problem*. Computing **62**, 189–203 (1999).
+    https://doi.org/10.1007/s006070050002.
 """
 struct DelCorsoManziniWithPS{D<:Union{Nothing,Integer}} <: AbstractDecider
     depth::D
@@ -246,10 +258,10 @@ _requires_symmetry(::DelCorsoManziniWithPS) = true
 
 Compute a (hopefully) near-optimal Del Corso–Manzini perimeter search depth for `A`.
 
-Taking experimental results from [DCM99; pp. 197–199](@cite) into account, this function
-tries to approximate the optimal depth parameter as a function of both matrix size and
-density. This depth parameter determines how large of a "perimeter" of last-placed indices
-is precomputed in the Del Corso–Manzini algorithm with perimeter search.
+Taking experimental results from [DM99, pp. 197–99] into account, this function tries to
+approximate the optimal depth parameter as a function of both matrix size and density. This
+depth parameter determines how large of a "perimeter" of last-placed indices is precomputed
+in the Del Corso–Manzini algorithm with perimeter search.
 
 # Arguments
 - `A::AbstractMatrix{Bool}`: the (structurally symmetric and square) input matrix whose
@@ -261,11 +273,17 @@ is precomputed in the Del Corso–Manzini algorithm with perimeter search.
 
 # Notes
 See Tables 4, 5, and 6 from the original paper for more details on experimental results
-regarding the optimal perimeter search depth [DCM99; pp. 197–199](@cite).
+regarding the optimal perimeter search depth [DM99, pp. 197–99].
 
 See also [`DelCorsoManziniWithPS`](@ref) and
 [`MatrixBandwidth.Minimization.Exact.DelCorsoManziniWithPS`](@ref)) for our implementation
 of the relevant bandwidth recognition and bandwidth minimization algorithms, respectively.
+
+# References
+
+- [DM99](@cite): G. M. Del Corso and G. Manzini. *Finding Exact Solutions to the Bandwidth
+    Minimization Problem*. Computing **62**, 189–203 (1999).
+    https://doi.org/10.1007/s006070050002.
 """
 function dcm_ps_optimal_depth(A::AbstractMatrix{Bool})
     n = size(A, 1)

--- a/src/Recognition/types.jl
+++ b/src/Recognition/types.jl
@@ -68,7 +68,7 @@ struct RecognitionResult{
     end
 end
 
-# The `Base.show` override here takes heavy inspiration from the `Optim.jl` package
+# The `Base.show` override here takes heavy inspiration from the Optim.jl package
 function Base.show(io::IO, res::RecognitionResult)
     n = size(res.matrix, 1)
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -102,16 +102,16 @@ Compute the profile of `A` before any permutation of its rows and columns.
 The *profile* of a structurally symmetric ``n×n`` matrix ``A`` is traditionally defined as
 the sum of the distances from each diagonal entry to the leftmost nonzero entry in that
 row—in other words, ``∑ᵢ₌₁ⁿ (i - fᵢ)``, where each ``fᵢ`` is the smallest index such that
-``A[i, fᵢ] ≠ 0`` [Maf14; pp. 187-88](@cite). Generalizing this property to all square
-matrices, we define the *column profile* of a matrix to be the sum of the distances from
-each diagonal entry to the farthest (not necessarily topmost) nonzero entry in that column
-and the *row profile* to be the sum of the distances from each diagonal entry to the
-farthest (not necessarily leftmost) nonzero entry in that row. (Note that both of these
-properties are equal to traditional matrix profile for structurally symmetric matrices.)
+``A[i, fᵢ] ≠ 0`` [Maf14, pp. 187-88]. Generalizing this property to all square matrices, we
+define the *column profile* of a matrix to be the sum of the distances from each diagonal
+entry to the farthest (not necessarily topmost) nonzero entry in that column and the *row
+profile* to be the sum of the distances from each diagonal entry to the farthest (not
+necessarily leftmost) nonzero entry in that row. (Note that both of these properties are
+equal to traditional matrix profile for structurally symmetric matrices.)
 
 One of the most common contexts in which matrix profile is relevant is sparse matrix
-storage, where lower-profile matrices occupy less space in memory [Maf14; p.188](@cite).
-Since Julia's `SparseArrays` package defaults to compressed sparse column storage over
+storage, where lower-profile matrices occupy less space in memory [Maf14, p.188]. Since
+Julia's *SparseArrays.jl* package defaults to compressed sparse column storage over
 compressed sparse row, we therefore compute column profile by default unless the dimension
 is otherwise specified.
 
@@ -176,6 +176,12 @@ julia> profile(A, dim=:row)
 julia> profile(A, dim=:col)
 175
 ```
+
+# References
+
+- [Maf14](@cite): L. O. Mafteiu-Scai. *The Bandwidths of a Matrix. A Survey of Algorithms*.
+    Annals of West University of Timisoara - Mathematics and Computer Science **52**,
+    183–223 (2014). https://doi.org/10.2478/awutm-2014-0019.
 """
 function profile(A::AbstractMatrix{<:Number}; dim::Symbol=:col)
     if dim == :col
@@ -217,11 +223,10 @@ end
 """
     bandwidth_lower_bound(A) -> Int
 
-Compute a lower bound on the bandwidth of `A` using [CSG05; pp. 359--60](@cite)'s results.
+Compute a lower bound on the bandwidth of `A` using [CS05, pp. 359--60]'s results.
 
-`A` is assumed to be structurally symmetric, since the bound from
-[CSG05; pp.359--60](@cite) was discovered in the context of undirected graphs (whose
-adjacency matrices are symmetric).
+`A` is assumed to be structurally symmetric, since the bound from [CS05, pp.359--60] was
+discovered in the context of undirected graphs (whose adjacency matrices are symmetric).
 
 The *bandwidth* of an ``n×n`` matrix ``A`` is the minimum non-negative integer
 ``k ∈ \\{0, 1, …, n - 1\\}`` such that ``A[i, j] = 0`` whenever ``|i - j| > k``.
@@ -279,6 +284,12 @@ tridiagonal matrices as bandwidth ``2``, and so on. Our definition, on the other
 more common in computer science contexts, treating diagonal matrices as bandwidth ``0`` and
 tridiagonal matrices as bandwidth ``1``. (Both definitions, however, agree that the
 bandwidth of an empty matrix is simply ``0``.)
+
+# References
+
+- [CS05](@cite): A. Caprara and J.-J. Salazar-González. *Laying Out Sparse Graphs with
+    Provably Minimum Bandwidth*. INFORMS Journal on Computing **17**, 356–73 (2005).
+    https://doi.org/10.1287/ijoc.1040.0083.
 """
 function bandwidth_lower_bound(A::AbstractMatrix{<:Number})
     if !allequal(size(A))

--- a/src/types.jl
+++ b/src/types.jl
@@ -212,11 +212,16 @@ raised when one of these algorithms is called with a structurally asymmetric inp
 
 # Notes
 As noted in the error message for `StructuralAsymmetryError` instances, users may want to
-consider symmetrization techniques from [RS06](@cite) to minimize the bandwidth of
-structurally asymmetric matrices. (A prominent one is to simply replace ``A[i, j]`` with
-``1`` whenever ``A[i, j] = 0`` but ``A[j, i] ≠ 0``.) Of course, the reliability of
-minimization algorithms is diminished after such a transformation, so users should proceed
-with caution nonetheless.
+consider symmetrization techniques from [RS06] to minimize the bandwidth of structurally
+asymmetric matrices. (A prominent one is to simply replace ``A[i, j]`` with ``1`` whenever
+``A[i, j] = 0`` but ``A[j, i] ≠ 0``.) Of course, the reliability of minimization algorithms
+is diminished after such a transformation, so users should proceed with caution nonetheless.
+
+# References
+
+- [RS06](@cite): J. K. Reid and J. A. Scott. *Reducing the Total Bandwidth of a Sparse
+    Unsymmetric Matrix*. SIAM Journal on Matrix Analysis and Applications **28**, 805–21
+    (2006). https://doi.org/10.1137/050629938.
 """
 struct StructuralAsymmetryError <: Exception
     A::AbstractMatrix{<:Number}

--- a/test/Minimization/Exact/Exact.jl
+++ b/test/Minimization/Exact/Exact.jl
@@ -7,7 +7,7 @@
 """
     TestExact
 
-Test suite for the `Minimization.Exact` submodule of the `MatrixBandwidth.jl` package.
+Test suite for the `Minimization.Exact` submodule of the *MatrixBandwidth.jl* package.
 """
 module TestExact
 

--- a/test/Minimization/Heuristic/Heuristic.jl
+++ b/test/Minimization/Heuristic/Heuristic.jl
@@ -7,7 +7,7 @@
 """
     TestHeuristic
 
-Test suite for the `Minimization.Heuristic` submodule of the `MatrixBandwidth.jl` package.
+Test suite for the `Minimization.Heuristic` submodule of the *MatrixBandwidth.jl* package.
 """
 module TestHeuristic
 

--- a/test/Minimization/Heuristic/test_utils.jl
+++ b/test/Minimization/Heuristic/test_utils.jl
@@ -10,8 +10,15 @@
 A sample input for testing the Cuthill–McKee and reverse Cuthill–McKee algorithms.
 
 The original matrix bandwidth is 8, and the expected outputs are provided in
-[`RCM_ANSWERS`](@ref). This example is taken from [LLS+01](@cite) (converted from C++'s
-zero-based indexing to Julia's one-based indexing).
+[`RCM_ANSWERS`](@ref). This example is taken from [LLS+01] (converted from C++'s zero-based
+indexing to Julia's one-based indexing).
+
+# References
+
+- [LLS+01](@cite): A. Lumsdaine, L.-Q. Lee, J. G. Siek, D. Gregor and K. D. McGrath,
+    *example/cuthillmckeeordering.cpp*. Boost v1.37.0 documentation (2001). Accessed:
+    2025-06-10.
+    https://www.boost.org/doc/libs/1_37_0/libs/graph/example/cuthill_mckee_ordering.cpp.
 """
 const RCM_INPUT = let
     n = 10
@@ -42,8 +49,8 @@ end
 Examples of outputs when reverse Cuthill–McKee is correctly applied to [`RCM_INPUT`](@ref).
 
 The first element of each tuple is the bandwidth of the reordered matrix, and the second is
-the new ordering of the rows and columns. This example is taken from [LLS+01](@cite)
-(converted from C++'s zero-based indexing to Julia's one-based indexing).
+the new ordering of the rows and columns. This example is taken from [LLS+01] (converted
+from C++'s zero-based indexing to Julia's one-based indexing).
 
 Note that these are only some possible outputs, as different node selection heuristics may
 yield different starting points and thus different orderings. Given matching starting nodes,
@@ -51,6 +58,13 @@ however, these are the expected results.
 
 If testing Cuthill–McKee instead of reverse Cuthill–McKee, the orderings can simply be
 reversed, although bandwidths may differ in the general case.
+
+# References
+
+- [LLS+01](@cite): A. Lumsdaine, L.-Q. Lee, J. G. Siek, D. Gregor and K. D. McGrath,
+    *example/cuthillmckeeordering.cpp*. Boost v1.37.0 documentation (2001). Accessed:
+    2025-06-10.
+    https://www.boost.org/doc/libs/1_37_0/libs/graph/example/cuthill_mckee_ordering.cpp.
 """
 const RCM_ANSWERS = [
     (4, [9, 4, 1, 10, 3, 6, 2, 5, 8, 7]),

--- a/test/Minimization/Metaheuristic/Metaheuristic.jl
+++ b/test/Minimization/Metaheuristic/Metaheuristic.jl
@@ -7,7 +7,7 @@
 """
     TestMetaheuristic
 
-Test suite for the `Minimization.Metaheuristic` submodule of the `MatrixBandwidth.jl`
+Test suite for the `Minimization.Metaheuristic` submodule of the *MatrixBandwidth.jl*
 package.
 """
 module TestMetaheuristic

--- a/test/Minimization/Minimization.jl
+++ b/test/Minimization/Minimization.jl
@@ -7,7 +7,7 @@
 """
     TestMinimization
 
-Test suite for the `Minimization` submodule of the `MatrixBandwidth.jl` package.
+Test suite for the `Minimization` submodule of the *MatrixBandwidth.jl* package.
 """
 module TestMinimization
 

--- a/test/Minimization/core.jl
+++ b/test/Minimization/core.jl
@@ -7,7 +7,7 @@
 """
     TestCore
 
-Test suite for the core API of the `Minimization` submodule of the `MatrixBandwidth.jl`
+Test suite for the core API of the `Minimization` submodule of the *MatrixBandwidth.jl*
 package.
 """
 module TestCore

--- a/test/Recognition/Recognition.jl
+++ b/test/Recognition/Recognition.jl
@@ -7,7 +7,7 @@
 """
     TestRecognition
 
-Test suite for the `Recognition` submodule of the `MatrixBandwidth.jl` package.
+Test suite for the `Recognition` submodule of the *MatrixBandwidth.jl* package.
 """
 module TestRecognition
 

--- a/test/Recognition/core.jl
+++ b/test/Recognition/core.jl
@@ -7,7 +7,7 @@
 """
     TestCore
 
-Test suite for the core API of the `Recognition` submodule of the `MatrixBandwidth.jl`
+Test suite for the core API of the `Recognition` submodule of the *MatrixBandwidth.jl*
 package.
 """
 module TestCore

--- a/test/core.jl
+++ b/test/core.jl
@@ -7,7 +7,7 @@
 """
     TestCore
 
-Test suite for the core API of the `MatrixBandwidth.jl` package.
+Test suite for the core API of the *MatrixBandwidth.jl* package.
 """
 module TestCore
 

--- a/test/static_analysis/aqua.jl
+++ b/test/static_analysis/aqua.jl
@@ -7,9 +7,9 @@
 """
     TestAqua
 
-Static analysis with `Aqua.jl` for the `MatrixBandwidth.jl` package.
+Static analysis with *Aqua.jl* for the *MatrixBandwidth.jl* package.
 
-`Aqua.jl` offers a general static analyzer, checking for method ambiguities, undefined
+*Aqua.jl* offers a general static analyzer, checking for method ambiguities, undefined
 `export`s, unbound type parameters, stale dependencies, type piracies, precompilation
 issues, and more.
 """

--- a/test/static_analysis/jet.jl
+++ b/test/static_analysis/jet.jl
@@ -7,9 +7,9 @@
 """
     TestJET
 
-Static analysis with `JET.jl` for the `MatrixBandwidth.jl` package.
+Static analysis with *JET.jl* for the *MatrixBandwidth.jl* package.
 
-`JET.jl` offers a specialized static analyzer focusing primarily on type instabilities,
+*JET.jl* offers a specialized static analyzer focusing primarily on type instabilities,
 type errors, and other issues detectable by Julia's type inference system.
 """
 module TestJET

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -7,7 +7,7 @@
 """
     TestUtils
 
-Test suite for the root-level utility functions of the `MatrixBandwidth.jl` package.
+Test suite for the root-level utility functions of the *MatrixBandwidth.jl* package.
 """
 module TestUtils
 


### PR DESCRIPTION
This PR adds References sections to docstrings with hardcoded typed-out bibliography entries pasted over from those generated on the Documenter website. This makes immediate readability of the citations from the REPL and the source code possible without having to visit the Documenter-generated website.

Additionally, inconsistency between code blocks and italicized text when referring to Julia package names (e.g., ABC.jl) is standardized to italics.

Finally, we add the original academic citation for 'pseudo_peripheral_node_finder' (not just the NetworkX secondary source).

(Closes #103.)