### PR TITLE
Move '_connected_components' to the root module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Finished unit tests for all root-level utility functions (#108).
+- Finished unit tests for all root-level utility functions (#108, #109).
 - Added **References** sections to docstrings for immediate readability in the REPL and in the source code without needing to open the Documenter-generated website (#105).
+
+### Changed
+
+- Moved the `_connected_components` function from `MatrixBandwidth.Minimization.Heuristic` to the root `MatrixBandwidth` module (specifically `src/utils.jl`) for universal access (#109).
 
 ## [0.1.3] - 2025-08-05
 

--- a/src/MatrixBandwidth.jl
+++ b/src/MatrixBandwidth.jl
@@ -72,6 +72,7 @@ The full documentation is available at
 """
 module MatrixBandwidth
 
+using DataStructures: Queue, enqueue!, dequeue!
 using Random
 using PrecompileTools: @setup_workload, @compile_workload
 

--- a/src/Minimization/Heuristic/Heuristic.jl
+++ b/src/Minimization/Heuristic/Heuristic.jl
@@ -33,6 +33,7 @@ import ..ALGORITHMS
 import ..AbstractSolver
 import ..NotImplementedError, ..StructuralAsymmetryError
 import .._requires_symmetry
+import .._connected_components
 import .._approach, .._bool_minimal_band_ordering
 #! format: on
 

--- a/src/Minimization/Heuristic/utils.jl
+++ b/src/Minimization/Heuristic/utils.jl
@@ -117,35 +117,3 @@ function _assert_valid_node_selector(selector::Function)
 
     return nothing
 end
-
-# Find the indices of all connected components in an adjacency matrix
-function _connected_components(A::AbstractMatrix{Bool})
-    n = size(A, 1)
-    visited = falses(n)
-    queue = Queue{Int}()
-    components = Vector{Int}[]
-
-    for i in 1:n
-        if !visited[i]
-            visited[i] = true
-            enqueue!(queue, i)
-            component = Int[]
-
-            while !isempty(queue)
-                u = dequeue!(queue)
-                push!(component, u)
-
-                for v in findall(view(A, :, u))
-                    if !visited[v]
-                        visited[v] = true
-                        enqueue!(queue, v)
-                    end
-                end
-            end
-
-            push!(components, component)
-        end
-    end
-
-    return components
-end

--- a/src/Minimization/Minimization.jl
+++ b/src/Minimization/Minimization.jl
@@ -50,7 +50,8 @@ import ..AbstractAlgorithm, ..AbstractResult
 import ..NotImplementedError, ..RectangularMatrixError, ..StructuralAsymmetryError
 import ..bandwidth, ..bandwidth_lower_bound
 import .._requires_symmetry, .._problem
-import .._find_direct_subtype, .._is_structurally_symmetric, .._offdiag_nonzero_support
+import .._connected_components,
+    .._find_direct_subtype, .._is_structurally_symmetric, .._offdiag_nonzero_support
 #! format: on
 
 ALGORITHMS[:Minimization] = Dict{Symbol,Vector}()

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -145,6 +145,38 @@ function random_banded_matrix(
     return A
 end
 
+# Find the indices of all connected components in an adjacency matrix
+function _connected_components(A::AbstractMatrix{Bool})
+    n = size(A, 1)
+    visited = falses(n)
+    queue = Queue{Int}()
+    components = Vector{Int}[]
+
+    for i in 1:n
+        if !visited[i]
+            visited[i] = true
+            enqueue!(queue, i)
+            component = Int[]
+
+            while !isempty(queue)
+                u = dequeue!(queue)
+                push!(component, u)
+
+                for v in findall(view(A, :, u))
+                    if !visited[v]
+                        visited[v] = true
+                        enqueue!(queue, v)
+                    end
+                end
+            end
+
+            push!(components, component)
+        end
+    end
+
+    return components
+end
+
 # Identify the highest supertype of `subtype` that is a subtype of `abstracttype`
 function _find_direct_subtype(abstracttype::Type, subtype::Type)
     if !isabstracttype(abstracttype)

--- a/test/core.jl
+++ b/test/core.jl
@@ -13,8 +13,8 @@ module TestCore
 
 using MatrixBandwidth
 using MatrixBandwidth.Minimization
-using SparseArrays
 using Graphs
+using SparseArrays
 using Test
 
 const MAX_ORDER1 = 80


### PR DESCRIPTION
This PR moves the '_connected_components' function from 'MatrixBandwidth.Minimization.Heuristic' to the root 'MatrixBandwidth' module (specifically 'src/utils.jl') for universal access. It also adds unit tests for this function, thus finishing unit tests for all root-level utility functions.