### PR TITLE
Finish SGS solver outline; fix CM typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- TODO: Implemented the Saxe&ndash;Gurari&ndash;Sudborough algorithm for both bandwidth minimization and bandwidth recognition (#110).
 - Finished unit tests for all root-level utility functions (#108, #109).
 - Added **References** sections to docstrings for immediate readability in the REPL and in the source code without needing to open the Documenter-generated website (#105).
 

--- a/src/Minimization/Exact/Exact.jl
+++ b/src/Minimization/Exact/Exact.jl
@@ -35,6 +35,7 @@ import ..AbstractSolver
 import ..NotImplementedError, ..StructuralAsymmetryError
 import ..bandwidth, ..bandwidth_lower_bound
 import .._requires_symmetry
+import .._connected_components
 import .._approach, .._bool_minimal_band_ordering
 #! format: on
 

--- a/src/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
+++ b/src/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
@@ -23,6 +23,23 @@ Base.summary(::SaxeGurariSudborough) = "Saxe–Gurari–Sudborough"
 _requires_symmetry(::SaxeGurariSudborough) = true
 
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::SaxeGurariSudborough)
-    error("TODO: Not yet implemented")
-    return nothing
+    components = _connected_components(A)
+    sort!(components; by=length)
+
+    ordering = Vector{Int}(undef, size(A, 1))
+    k = bandwidth_lower_bound(A)
+    num_placed = 0
+
+    for component in components
+        submatrix = view(A, component, component)
+        component_ordering = Recognition._sgs_connected_ordering(submatrix, k)
+
+        while isnothing(component_ordering)
+            component_ordering = Recognition._sgs_connected_ordering(submatrix, k += 1)
+        end
+
+        ordering[(num_placed + 1):(num_placed += length(component))] .= component[component_ordering]
+    end
+
+    return ordering
 end

--- a/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
+++ b/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
@@ -442,8 +442,8 @@ _requires_symmetry(::ReverseCuthillMcKee) = true
 
 #= We take advantage of the laziness of `Iterators.map` and `Iterators.flatmap` to avoid
 allocating `component_orderings` or individual `component[component_ordering]` arrays.
-(Indeed, the only allocations performed here are those performed by `_connected_components`
-, individual `_cm_connected_ordering` calls, and `collect` at the very end.) =#
+(Indeed, the only allocations performed here are those performed by `_connected_components`,
+individual `_cm_connected_ordering` calls, and `collect` at the very end.) =#
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, solver::CuthillMcKee)
     node_selector = solver.node_selector
     components = _connected_components(A)

--- a/src/Recognition/Recognition.jl
+++ b/src/Recognition/Recognition.jl
@@ -39,7 +39,7 @@ import ..AbstractAlgorithm, ..AbstractResult
 import ..NotImplementedError, ..RectangularMatrixError, ..StructuralAsymmetryError
 import ..bandwidth, ..bandwidth_lower_bound
 import .._problem
-import .._is_structurally_symmetric, .._offdiag_nonzero_support
+import .._connected_components, .._is_structurally_symmetric, .._offdiag_nonzero_support
 #! format: on
 
 using Combinatorics: combinations, permutations

--- a/src/Recognition/deciders/saxe_gurari_sudborough.jl
+++ b/src/Recognition/deciders/saxe_gurari_sudborough.jl
@@ -20,9 +20,16 @@ struct SaxeGurariSudborough <: AbstractDecider end
 
 Base.summary(::SaxeGurariSudborough) = "Saxe–Gurari–Sudborough"
 
+_requires_symmetry(::SaxeGurariSudborough) = true
+
 function _bool_bandwidth_k_ordering(
     A::AbstractMatrix{Bool}, k::Integer, ::SaxeGurariSudborough
 )
+    error("TODO: Not yet implemented")
+    return nothing
+end
+
+function _sgs_connected_ordering(A::AbstractMatrix{Bool}, k::Integer)
     error("TODO: Not yet implemented")
     return nothing
 end


### PR DESCRIPTION
This PR finishes the solver logic for Saxe-Gurari-Sudborough, which calls the Recognition decider (not yet done) as a subroutine. (Hence, the solver doesn't actually work yet, but it does not need to be modified any further, it just needs the decider logic to be completed.)

Additionally, we identify a typo in the documentation for Cuthill-McKee.