### PR TITLE
Fix restrictive test params; further reduce runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Reduced the number of iterations and cases in some of the unit tests to cut down on runtime without affecting coverage (#112, #113, #118, #119).
 - Fleshed out documentation (particularly inline comments) for the Gibbs&ndash;Poole&ndash;Stockmeyer source code (#116).
-- Reduced the number of iterations and cases in some of the unit tests to cut down on runtime without affecting coverage (#112, #113).
 - Improved unit tests for the heuristic solvers with more edge cases and scenarios (including the use of custom node finders) (#112).
 - Changed the `DEFAULT_NODE_FINDER` constant for the heuristic solvers from `pseudo_peripheral_node_finder` to `bi_criteria_node_finder` (#112).
 - Moved the `_connected_components` function from `MatrixBandwidth.Minimization.Heuristic` to the root `MatrixBandwidth` module (specifically `src/utils.jl`) for universal access (#109).

--- a/test/Minimization/Exact/solvers/del_corso_manzini.jl
+++ b/test/Minimization/Exact/solvers/del_corso_manzini.jl
@@ -18,7 +18,7 @@ using SparseArrays
 using Test
 
 const MAX_ORDER = 6
-const NUM_ITER = 15
+const NUM_ITER = 5
 
 @testset "DCM solver – Brute force verification (n ≤ $MAX_ORDER)" begin
     for n in 1:MAX_ORDER, _ in 1:NUM_ITER

--- a/test/Minimization/Heuristic/solvers/cuthill_mckee.jl
+++ b/test/Minimization/Heuristic/solvers/cuthill_mckee.jl
@@ -71,10 +71,10 @@ bands (pre-shuffling). The default Hou, Liu, and Zhu (2024) node finder is used 
             res = minimize_bandwidth(A, ReverseCuthillMcKee())
 
             #= Confirm that the ratio of the minimized bandwidth to the original is not too
-            large. (In very rare cases, it is possible that the original ordering of `A` is not
+            large. (In some cases, it is possible that the original ordering of `A` is not
             optimal and that reverse Cuthill–McKee produces an even better one.) =#
             mult_error = res.bandwidth / k
-            @test mult_error < 2.5
+            @test mult_error < 3
 
             sum_mult_errors += mult_error
             num_cases += 1
@@ -86,7 +86,7 @@ bands (pre-shuffling). The default Hou, Liu, and Zhu (2024) node finder is used 
 
     #= We keep track of the average ratio of the minimized bandwidth to the original
     bandwidth, which should be less than 1.5 if the algorithm is working properly. =#
-    @test sum_mult_errors / num_cases < 1.25
+    @test sum_mult_errors / num_cases < 1.5
 end
 
 #= Here we specify the node finder, using the traditional George and Liu (1979) algorithm
@@ -110,7 +110,7 @@ end
             res = minimize_bandwidth(A, ReverseCuthillMcKee(gl_node_finder))
 
             mult_error = res.bandwidth / k
-            @test mult_error < 2.5
+            @test mult_error < 3
 
             sum_mult_errors += mult_error
             num_cases += 1
@@ -119,7 +119,7 @@ end
         end
     end
 
-    @test sum_mult_errors / num_cases < 1.25
+    @test sum_mult_errors / num_cases < 1.5
 end
 
 #= Now a (far inferior) naive node finder is used, simply selecting the node with the lowest
@@ -145,7 +145,7 @@ Gibbs–Poole–Stockmeyer continues to prove effective (although less so) nonet
             res = minimize_bandwidth(A, GibbsPooleStockmeyer(naive_node_finder))
 
             mult_error = res.bandwidth / k
-            @test mult_error < 2.5
+            @test mult_error < 3
 
             sum_mult_errors += mult_error
             num_cases += 1
@@ -154,7 +154,7 @@ Gibbs–Poole–Stockmeyer continues to prove effective (although less so) nonet
         end
     end
 
-    @test sum_mult_errors / num_cases < 1.25
+    @test sum_mult_errors / num_cases < 1.5
 end
 
 end

--- a/test/Minimization/Heuristic/solvers/gibbs_poole_stockmeyer.jl
+++ b/test/Minimization/Heuristic/solvers/gibbs_poole_stockmeyer.jl
@@ -50,10 +50,10 @@ bands (pre-shuffling). The default Hou, Liu, and Zhu (2024) node finder is used 
             res = minimize_bandwidth(A, GibbsPooleStockmeyer())
 
             #= Confirm that the ratio of the minimized bandwidth to the original is not too
-            large. (In very rare cases, it is possible that the original ordering of `A` is
+            large. (In some cases, it is possible that the original ordering of `A` is not
             not optimal and that Gibbs–Poole–Stockmeyer produces an even better one.) =#
             mult_error = res.bandwidth / k
-            @test mult_error < 2.5
+            @test mult_error < 3
 
             sum_mult_errors += mult_error
             num_cases += 1
@@ -65,7 +65,7 @@ bands (pre-shuffling). The default Hou, Liu, and Zhu (2024) node finder is used 
 
     #= We keep track of the average ratio of the minimized bandwidth to the original
     bandwidth, which should be less than 1.5 if the algorithm is working properly. =#
-    @test sum_mult_errors / num_cases < 1.25
+    @test sum_mult_errors / num_cases < 1.5
 end
 
 #= Here we specify the node finder, using the traditional George and Liu (1979) algorithm
@@ -89,7 +89,7 @@ end
             res = minimize_bandwidth(A, GibbsPooleStockmeyer(gl_node_finder))
 
             mult_error = res.bandwidth / k
-            @test mult_error < 2.5
+            @test mult_error < 3
 
             sum_mult_errors += mult_error
             num_cases += 1
@@ -98,7 +98,7 @@ end
         end
     end
 
-    @test sum_mult_errors / num_cases < 1.25
+    @test sum_mult_errors / num_cases < 1.5
 end
 
 #= Now a (far inferior) naive node finder is used, simply selecting the node with the lowest
@@ -124,7 +124,7 @@ Gibbs–Poole–Stockmeyer continues to prove effective (although less so) nonet
             res = minimize_bandwidth(A, GibbsPooleStockmeyer(naive_node_finder))
 
             mult_error = res.bandwidth / k
-            @test mult_error < 2.5
+            @test mult_error < 3
 
             sum_mult_errors += mult_error
             num_cases += 1
@@ -133,7 +133,7 @@ Gibbs–Poole–Stockmeyer continues to prove effective (although less so) nonet
         end
     end
 
-    @test sum_mult_errors / num_cases < 1.25
+    @test sum_mult_errors / num_cases < 1.5
 end
 
 end

--- a/test/Recognition/deciders/del_corso_manzini.jl
+++ b/test/Recognition/deciders/del_corso_manzini.jl
@@ -17,7 +17,7 @@ using SparseArrays
 using Test
 
 const MAX_ORDER = 6
-const NUM_ITER = 15
+const NUM_ITER = 5
 
 @testset "DCM decider – Bandwidth < k (n ≤ $MAX_ORDER)" begin
     for n in 2:MAX_ORDER, i in 1:NUM_ITER

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -18,7 +18,7 @@ using SparseArrays
 using Test
 
 const MAX_ORDER = 35
-const CC_NUM_ITER = 15
+const CC_NUM_ITER = 5
 const CC_MAX_DENSITY = 0.5
 const CC_MAX_NUM_CCS = 3
 const N = 100


### PR DESCRIPTION
This PR further reduces the runtime of some of the unit tests and adjusts some overly restrictive parameters in the (reverse) Cuthill-McKee and Gibbs-Poole-Stockmeyer test suites.