### PR TITLE
Finish SGS; rename '_requires_symmetry'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Implemented the Saxe&ndash;Gurari&ndash;Sudborough algorithm (both the minimization solver and the recognition decider) (#123). (**NOTE:** Some documentation is still pending.)
 - Added `bi_criteria_node_finder` (an improvement upon `pseudo_peripheral_node_finder`) as a new node finder for the heuristic solvers (#112).
 - Finished unit tests for all root-level utility functions (#108, #109).
 - Added **References** sections to docstrings for immediate readability in the REPL and in the source code without needing to open the Documenter-generated website (#105).
 
 ### Changed
 
+- Renamed the `_requires_symmetry` internal function (used for input validation) to `_requires_structural_symmetry` (#123).
 - Reduced the number of iterations and cases in some of the unit tests to cut down on runtime without affecting coverage (#112, #113, #118, #119).
 - Fleshed out documentation (particularly inline comments) for the Gibbs&ndash;Poole&ndash;Stockmeyer source code (#116).
 - Improved unit tests for the heuristic solvers with more edge cases and scenarios (including the use of custom node finders) (#112).
 - Changed the `DEFAULT_NODE_FINDER` constant for the heuristic solvers from `pseudo_peripheral_node_finder` to `bi_criteria_node_finder` (#112).
 - Moved the `_connected_components` function from `MatrixBandwidth.Minimization.Heuristic` to the root `MatrixBandwidth` module (specifically `src/utils.jl`) for universal access (#109).
+
+### Fixed
+
+- Fixed some test names in the Del Corso&ndash;Manzini recognition algorithm test suite ("Bandwidth < k" was meant to be "Bandwidth > k", and "Bandwidth ≥ k" was meant to be "Bandwidth ≤ k") (#123).
 
 ## [0.1.3] - 2025-08-05
 

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -69,6 +69,19 @@
   url = {https://doi.org/10.1137/0713023}
 }
 
+@article{GS84,
+  author = {Gurari, Eitan M. and Sudborough, Ival Hal},
+  journal = {Journal of Algorithms},
+  number = {4},
+  title = {Improved dynamic programming algorithms for bandwidth minimization and the
+  MinCut Linear Arrangement problem},
+  volume = {5},
+  year = {1984},
+  pages = {531--46},
+  doi = {10.1016/0196-6774(84)90006-3},
+  url = {https://doi.org/10.1016/0196-6774(84)90006-3}
+}
+
 @misc{HLZ24,
   author = {Hou, JiaJun and Liu, HongJie and Zhu, ShengXin},
   title = {RCM++:Reverse Cuthill-McKee ordering with Bi-Criteria Node Finder},
@@ -91,7 +104,8 @@
 }
 
 @misc{LLS+01,
-  author = {Lumsdaine, Andrew and Lee, Lie-Quan and Siek, Jeremy G. and Gregor, Doug and McGrath, Kevin D.},
+  author = {Lumsdaine, Andrew and Lee, Lie-Quan and Siek, Jeremy G. and Gregor, Doug and
+  McGrath, Kevin D.},
   howpublished = {Boost v1.37.0 documentation},
   title = {example/cuthill_mckee_ordering.cpp},
   year = {2001},
@@ -128,4 +142,16 @@
   pages = {805--21},
   year = {2006},
   url = {https://doi.org/10.1137/050629938}
+}
+
+@article{Sax80,
+  author = {Saxe, James B.},
+  journal = {SIAM Journal on Algebraic and Discrete Methods},
+  number = {4},
+  title = {Dynamic-Programming Algorithms for Recognizing Small-Bandwidth Graphs in
+  Polynomial Time},
+  volume = {1},
+  pages = {363--69},
+  year = {1980},
+  url = {https://doi.org/10.1137/0601042}
 }

--- a/src/Minimization/Exact/Exact.jl
+++ b/src/Minimization/Exact/Exact.jl
@@ -34,7 +34,7 @@ import ..ALGORITHMS
 import ..AbstractSolver
 import ..NotImplementedError, ..StructuralAsymmetryError
 import ..bandwidth, ..bandwidth_lower_bound
-import .._requires_symmetry
+import .._requires_structural_symmetry
 import .._connected_components
 import .._approach, .._bool_minimal_band_ordering
 #! format: on

--- a/src/Minimization/Exact/solvers/brute_force_search.jl
+++ b/src/Minimization/Exact/solvers/brute_force_search.jl
@@ -68,7 +68,7 @@ push!(ALGORITHMS[:Minimization][:Exact], BruteForceSearch)
 
 Base.summary(::BruteForceSearch) = "Brute-force search"
 
-_requires_symmetry(::BruteForceSearch) = false
+_requires_structural_symmetry(::BruteForceSearch) = false
 
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::BruteForceSearch)
     #= `i₁, i₂, … iₙ` induces the same bandwidth as `iₙ, iₙ₋₁, … i₁`, so without loss of

--- a/src/Minimization/Exact/solvers/caprara_salazar_gonzalez.jl
+++ b/src/Minimization/Exact/solvers/caprara_salazar_gonzalez.jl
@@ -47,7 +47,7 @@ struct CapraraSalazarGonzalez <: ExactSolver end
 
 Base.summary(::CapraraSalazarGonzalez) = "Caprara–Salazar-González"
 
-_requires_symmetry(::CapraraSalazarGonzalez) = true
+_requires_structural_symmetry(::CapraraSalazarGonzalez) = true
 
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::CapraraSalazarGonzalez)
     error("TODO: Not yet implemented")

--- a/src/Minimization/Exact/solvers/del_corso_manzini.jl
+++ b/src/Minimization/Exact/solvers/del_corso_manzini.jl
@@ -136,7 +136,7 @@ push!(ALGORITHMS[:Minimization][:Exact], DelCorsoManzini)
 
 Base.summary(::DelCorsoManzini) = "Del Corso–Manzini"
 
-_requires_symmetry(::DelCorsoManzini) = true
+_requires_structural_symmetry(::DelCorsoManzini) = true
 
 """
     DelCorsoManziniWithPS{D} <: ExactSolver <: AbstractSolver <: AbstractAlgorithm
@@ -318,7 +318,7 @@ push!(ALGORITHMS[:Minimization][:Exact], DelCorsoManziniWithPS)
 
 Base.summary(::DelCorsoManziniWithPS) = "Del Corso–Manzini with perimeter search"
 
-_requires_symmetry(::DelCorsoManziniWithPS) = true
+_requires_structural_symmetry(::DelCorsoManziniWithPS) = true
 
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::DelCorsoManzini)
     n = size(A, 1)

--- a/src/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
+++ b/src/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
@@ -12,26 +12,59 @@
 # Supertype Hierarchy
 `SaxeGurariSudborough` <: [`ExactSolver`](@ref) <: [`AbstractSolver`](@ref) <: [`MatrixBandwidth.AbstractAlgorithm`](@ref)
 
+# Performance
+Given an ``n×n`` input matrix ``A``, the Saxe–Gurari–Sudborough algorithm runs in
+``O(nⁿ⁻¹)`` time:
+- For each underlying "bandwidth ≤ k" check, we call the Saxe–Gurari–Sudborough recognition
+  algorithm, which runs in ``O(nᵏ)`` time [GS84, p. 531]. (This is an improvement upon the
+  original ``O(nᵏ⁺¹)`` Saxe algorithm [Sax80, p. 363].)
+- The difference between the maximum possible bandwidth (``n - 1``) and our initial lower
+    bound grows linearly in ``n``, so we run the underlying ``O(nᵏ)`` recognition algorithm
+    ``O(n)`` times.
+- Therefore, the overall time complexity is ``∑ₖ₌₀ⁿ⁻¹ nᵏ = O(nⁿ⁻¹)``.
+
+# Examples
 [TODO: Write here]
+
+# Notes
+Whereas most exact bandwidth minimization algorithms are technically factorial-time (with
+respect to ``n``) in the worst case but practically always approximate exponential time
+complexity in real life, the ``O(nⁿ⁻¹)`` upper bound on Saxe–Gurari–Sudborough is typically
+a good representation of actual performance in most cases. Indeed, these other types of
+algorithms tend to outperform Saxe–Gurari–Sudborough for larger ``n``, given that their
+aggressive pruning strategies keep their effective search space very small in practice and
+``O(2ⁿ)`` ⊂ ``O(nⁿ⁻¹)``.
+
+# References
+- [GS84](@cite): E. M. Gurari and I. H. Sudborough. *Improved dynamic programming algorithms
+    for bandwidth minimization and the MinCut Linear Arrangement problem*. Journal of
+    Algorithms **5**, 531–46 (1984). https://doi.org/10.1016/0196-6774(84)90006-3.
+- [Sax80](@cite): J. B. Saxe. *Dynamic-Programming Algorithms for Recognizing
+    Small-Bandwidth Graphs in Polynomial Time*. SIAM Journal on Algebraic and Discrete
+    Methods **1**, 363–69 (1980). https://doi.org/10.1137/0601042.
 """
 struct SaxeGurariSudborough <: ExactSolver end
 
-# push!(ALGORITHMS[:Minimization][:Exact], SaxeGurariSudborough)
+push!(ALGORITHMS[:Minimization][:Exact], SaxeGurariSudborough)
 
 Base.summary(::SaxeGurariSudborough) = "Saxe–Gurari–Sudborough"
 
-_requires_symmetry(::SaxeGurariSudborough) = true
+_requires_structural_symmetry(::SaxeGurariSudborough) = true
 
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::SaxeGurariSudborough)
     components = _connected_components(A)
+    #= Heuristically, it is likelier that smaller components have lower bandwidth, so we
+    process them first to keep `k` low for as long as possible (since the complexity of each
+    recognition subroutine is exponential in `k`). =#
     sort!(components; by=length)
 
     ordering = Vector{Int}(undef, size(A, 1))
-    k = bandwidth_lower_bound(A)
+    k = 1
     num_placed = 0
 
     for component in components
         submatrix = view(A, component, component)
+        k = max(k, bandwidth_lower_bound(submatrix))
         component_ordering = Recognition._sgs_connected_ordering(submatrix, k)
 
         while isnothing(component_ordering)

--- a/src/Minimization/Heuristic/Heuristic.jl
+++ b/src/Minimization/Heuristic/Heuristic.jl
@@ -32,7 +32,7 @@ module Heuristic
 import ..ALGORITHMS
 import ..AbstractSolver
 import ..NotImplementedError, ..StructuralAsymmetryError
-import .._requires_symmetry
+import .._requires_structural_symmetry
 import .._connected_components
 import .._approach, .._bool_minimal_band_ordering
 #! format: on

--- a/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
+++ b/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
@@ -218,7 +218,7 @@ push!(ALGORITHMS[:Minimization][:Heuristic], CuthillMcKee)
 
 Base.summary(::CuthillMcKee) = "Cuthill–McKee"
 
-_requires_symmetry(::CuthillMcKee) = true
+_requires_structural_symmetry(::CuthillMcKee) = true
 
 """
     ReverseCuthillMcKee <: HeuristicSolver <: AbstractSolver <: AbstractAlgorithm
@@ -438,7 +438,7 @@ push!(ALGORITHMS[:Minimization][:Heuristic], ReverseCuthillMcKee)
 
 Base.summary(::ReverseCuthillMcKee) = "Reverse Cuthill–McKee"
 
-_requires_symmetry(::ReverseCuthillMcKee) = true
+_requires_structural_symmetry(::ReverseCuthillMcKee) = true
 
 #= We take advantage of the laziness of `Iterators.map` and `Iterators.flatmap` to avoid
 allocating `component_orderings` or individual `component[component_ordering]` arrays.

--- a/src/Minimization/Heuristic/solvers/gibbs_poole_stockmeyer.jl
+++ b/src/Minimization/Heuristic/solvers/gibbs_poole_stockmeyer.jl
@@ -233,7 +233,7 @@ push!(ALGORITHMS[:Minimization][:Heuristic], GibbsPooleStockmeyer)
 
 Base.summary(::GibbsPooleStockmeyer) = "Gibbs–Poole–Stockmeyer"
 
-_requires_symmetry(::GibbsPooleStockmeyer) = true
+_requires_structural_symmetry(::GibbsPooleStockmeyer) = true
 
 #= We take advantage of the laziness of `Iterators.map` and `Iterators.flatmap` to avoid
 allocating `component_orderings` or individual `component[component_ordering]` arrays.

--- a/src/Minimization/Metaheuristic/Metaheuristic.jl
+++ b/src/Minimization/Metaheuristic/Metaheuristic.jl
@@ -31,7 +31,7 @@ module Metaheuristic
 import ..ALGORITHMS
 import ..AbstractSolver
 import ..NotImplementedError
-import .._requires_symmetry
+import .._requires_structural_symmetry
 import .._approach, .._bool_minimal_band_ordering
 #! format: on
 

--- a/src/Minimization/Metaheuristic/solvers/genetic_algorithm.jl
+++ b/src/Minimization/Metaheuristic/solvers/genetic_algorithm.jl
@@ -22,7 +22,7 @@ end
 
 Base.summary(::GeneticAlgorithm) = "Genetic algorithm"
 
-_requires_symmetry(::GeneticAlgorithm) = false
+_requires_structural_symmetry(::GeneticAlgorithm) = false
 
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, solver::GeneticAlgorithm)
     error("TODO: Not yet implemented")

--- a/src/Minimization/Metaheuristic/solvers/grasp.jl
+++ b/src/Minimization/Metaheuristic/solvers/grasp.jl
@@ -22,7 +22,7 @@ end
 
 Base.summary(::GRASP) = "Greedy randomized adaptive search procedure (GRASP)"
 
-_requires_symmetry(::GRASP) = false
+_requires_structural_symmetry(::GRASP) = false
 
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, Solver::GRASP)
     error("TODO: Not yet implemented")

--- a/src/Minimization/Metaheuristic/solvers/simulated_annealing.jl
+++ b/src/Minimization/Metaheuristic/solvers/simulated_annealing.jl
@@ -28,7 +28,7 @@ end
 
 Base.summary(::SimulatedAnnealing) = "Simulated annealing"
 
-_requires_symmetry(::SimulatedAnnealing) = false
+_requires_structural_symmetry(::SimulatedAnnealing) = false
 
 function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, solver::SimulatedAnnealing)
     error("TODO: Not yet implemented")

--- a/src/Minimization/Minimization.jl
+++ b/src/Minimization/Minimization.jl
@@ -49,7 +49,7 @@ import ..ALGORITHMS
 import ..AbstractAlgorithm, ..AbstractResult
 import ..NotImplementedError, ..RectangularMatrixError, ..StructuralAsymmetryError
 import ..bandwidth, ..bandwidth_lower_bound
-import .._requires_symmetry, .._problem
+import .._requires_structural_symmetry, .._problem
 import .._connected_components,
     .._find_direct_subtype, .._is_structurally_symmetric, .._offdiag_nonzero_support
 #! format: on

--- a/src/Minimization/core.jl
+++ b/src/Minimization/core.jl
@@ -54,7 +54,7 @@ function minimize_bandwidth(
         throw(RectangularMatrixError(A))
     end
 
-    if _requires_symmetry(solver) && !_is_structurally_symmetric(A)
+    if _requires_structural_symmetry(solver) && !_is_structurally_symmetric(A)
         throw(StructuralAsymmetryError(A, solver))
     end
 

--- a/src/Minimization/types.jl
+++ b/src/Minimization/types.jl
@@ -14,8 +14,8 @@ As per the interface of supertype [`AbstractAlgorithm`](@ref), concrete subtypes
 `AbstractSolver` must implement the following methods:
 - `Base.summary(::T) where {T<:AbstractSolver}`: returns a `String` indicating the name
     of the solver (e.g., `"Gibbs–Poole–Stockmeyer"`).
-- `_requires_symmetry(::T) where {T<:AbstractSolver}`: returns a `Bool` indicating
-    whether the solver requires the input matrix to be structurally symmetric.
+- `_requires_structural_symmetry(::T) where {T<:AbstractSolver}`: returns a `Bool`
+    indicating whether the solver requires the input matrix to be structurally symmetric.
 
 Direct subtypes of `AbstractSolver` must implement the following method:
 - `_approach(::T) where {T<:AbstractSolver}`: returns a `Symbol` indicating the

--- a/src/Recognition/core.jl
+++ b/src/Recognition/core.jl
@@ -59,7 +59,7 @@ function has_bandwidth_k_ordering(
         throw(RectangularMatrixError(A))
     end
 
-    if _requires_symmetry(decider) && !_is_structurally_symmetric(A)
+    if _requires_structural_symmetry(decider) && !_is_structurally_symmetric(A)
         throw(StructuralAsymmetryError(A, decider))
     end
 

--- a/src/Recognition/deciders/brute_force_search.jl
+++ b/src/Recognition/deciders/brute_force_search.jl
@@ -88,7 +88,7 @@ push!(ALGORITHMS[:Recognition], BruteForceSearch)
 
 Base.summary(::BruteForceSearch) = "Brute-force search"
 
-_requires_symmetry(::BruteForceSearch) = false
+_requires_structural_symmetry(::BruteForceSearch) = false
 
 #= We take advantage of the laziness of `permutations` and `Iterators.filter` to avoid
 iterating over all orderings if a valid one is found early. =#

--- a/src/Recognition/deciders/caprara_salazar_gonzalez.jl
+++ b/src/Recognition/deciders/caprara_salazar_gonzalez.jl
@@ -50,7 +50,7 @@ struct CapraraSalazarGonzalez <: AbstractDecider end
 
 Base.summary(::CapraraSalazarGonzalez) = "Caprara–Salazar-González"
 
-_requires_symmetry(::CapraraSalazarGonzalez) = true
+_requires_structural_symmetry(::CapraraSalazarGonzalez) = true
 
 function _bool_bandwidth_k_ordering(
     A::AbstractMatrix{Bool}, k::Integer, ::CapraraSalazarGonzalez

--- a/src/Recognition/deciders/del_corso_manzini.jl
+++ b/src/Recognition/deciders/del_corso_manzini.jl
@@ -95,7 +95,7 @@ push!(ALGORITHMS[:Recognition], DelCorsoManzini)
 
 Base.summary(::DelCorsoManzini) = "Del Corso–Manzini"
 
-_requires_symmetry(::DelCorsoManzini) = true
+_requires_structural_symmetry(::DelCorsoManzini) = true
 
 """
     DelCorsoManziniWithPS{D} <: AbstractDecider <: AbstractAlgorithm
@@ -249,7 +249,7 @@ push!(ALGORITHMS[:Recognition], DelCorsoManziniWithPS)
 
 Base.summary(::DelCorsoManziniWithPS) = "Del Corso–Manzini with perimeter search"
 
-_requires_symmetry(::DelCorsoManziniWithPS) = true
+_requires_structural_symmetry(::DelCorsoManziniWithPS) = true
 
 """
     dcm_ps_optimal_depth(A) -> Int

--- a/src/Recognition/deciders/saxe_gurari_sudborough.jl
+++ b/src/Recognition/deciders/saxe_gurari_sudborough.jl
@@ -13,23 +13,272 @@
 `SaxeGurariSudborough` <: [`AbstractDecider`](@ref) <: [`AbstractAlgorithm`](@ref)
 
 [TODO: Write here]
+
+# Performance
+Given an ``n×n`` input matrix ``A`` and threshold bandwidth ``k``, the
+Saxe–Gurari–Sudborough algorithm runs in ``O(nᵏ)`` time [GS84, p. 531]. This is an
+improvement upon the original ``O(nᵏ⁺¹)`` Saxe algorithm [Sax80, p. 363].
+
+Of course, when ``k < 3``, then the initial ``O(n³)`` bandwidth lower bound computation
+(specifically, [`bandwidth_lower_bound`](@ref)) performed in all
+[`has_bandwidth_k_ordering`](@ref) calls dominates the overall complexity (although the
+constant scaling factor of that subroutine is generally much smaller than that of the
+algorithm proper).
+
+# Examples
+[TODO: Write here]
+
+# Notes
+Whereas most bandwidth recognition algorithms are technically factorial-time (with respect
+to ``n``) in the worst case but practically always approximate exponential time complexity
+in real life (see: [`DelCorsoManzini`](@ref)), the ``O(nᵏ)`` upper bound on
+Saxe–Gurari–Sudborough is typically a good representation of actual performance in most
+cases. Indeed, these other types of algorithms tend to outperform Saxe–Gurari–Sudborough
+for larger ``k``, given that their aggressive pruning strategies keep their effective search
+space very small in practice.
+
+# References
+- [GS84](@cite): E. M. Gurari and I. H. Sudborough. *Improved dynamic programming algorithms
+    for bandwidth minimization and the MinCut Linear Arrangement problem*. Journal of
+    Algorithms **5**, 531–46 (1984). https://doi.org/10.1016/0196-6774(84)90006-3.
+- [Sax80](@cite): J. B. Saxe. *Dynamic-Programming Algorithms for Recognizing
+    Small-Bandwidth Graphs in Polynomial Time*. SIAM Journal on Algebraic and Discrete
+    Methods **1**, 363–69 (1980). https://doi.org/10.1137/0601042.
 """
 struct SaxeGurariSudborough <: AbstractDecider end
 
-# push!(ALGORITHMS[:Recognition], SaxeGurariSudborough)
+push!(ALGORITHMS[:Recognition], SaxeGurariSudborough)
 
 Base.summary(::SaxeGurariSudborough) = "Saxe–Gurari–Sudborough"
 
-_requires_symmetry(::SaxeGurariSudborough) = true
+_requires_structural_symmetry(::SaxeGurariSudborough) = true
 
 function _bool_bandwidth_k_ordering(
     A::AbstractMatrix{Bool}, k::Integer, ::SaxeGurariSudborough
 )
-    error("TODO: Not yet implemented")
+    components = _connected_components(A)
+    #= Smaller components take less time to process, so we do them first to heuristically
+    break earlier in some situtations and avoid wasting time on larger components. =#
+    sort!(components; by=length)
+
+    n = size(A, 1)
+    ordering = Vector{Int}(undef, n)
+    res = iterate(components)
+    num_placed = 0
+
+    while !isnothing(res)
+        (component, state) = res
+        submatrix = view(A, component, component)
+        component_ordering = _sgs_connected_ordering(submatrix, k)
+
+        if isnothing(component_ordering)
+            res = nothing
+        else
+            ordering[(num_placed + 1):(num_placed += length(component))] .= component[component_ordering]
+            res = iterate(components, state)
+        end
+    end
+
+    if num_placed < n
+        ordering = nothing
+    end
+
+    return ordering
+end
+
+# TODO: After this point, more comprehensive inline comments are required.
+
+function _sgs_connected_ordering(A::AbstractMatrix{Bool}, k::Integer)
+    n = size(A, 1)
+    adj_lists = map(node -> findall(view(A, :, node)), 1:n)
+
+    KeyType = Tuple{Tuple{Vararg{Int}},Tuple{Vararg{Tuple{Int,Int}}}}
+    parent = Dict{KeyType,Tuple{Union{Nothing,KeyType},Union{Nothing,Int}}}()
+    nums_placed = Dict{KeyType,Int}()
+    queue = Queue{KeyType}()
+    visited = Set{KeyType}()
+
+    empty_key = ((), ())
+    parent[empty_key] = (nothing, nothing)
+    nums_placed[empty_key] = 0
+    enqueue!(queue, empty_key)
+    push!(visited, empty_key)
+
+    while !isempty(queue)
+        key = dequeue!(queue)
+        num_placed = nums_placed[key]
+        region = collect(Int, key[1])
+        dangling = Set{Tuple{Int,Int}}(key[2])
+
+        if length(region) < k
+            candidates = _sgs_unassigned(region, dangling, adj_lists)
+        else
+            u = region[1]
+            edge = first(Iterators.filter(edge -> u in edge, dangling))
+
+            if u == edge[1]
+                v = edge[2]
+            else
+                v = edge[1]
+            end
+
+            candidates = Set(v)
+        end
+
+        for v in candidates
+            dangling_new = _sgs_dangling_new(region, dangling, v, adj_lists[v])
+            region_extended = vcat(region, v)
+            region_new = _sgs_region_new(region_extended, dangling_new, k)
+
+            if !isnothing(region_new)
+                key_new = _sgs_key(region_new, dangling_new)
+
+                if _sgs_layout_is_plausible(region_new, dangling_new, k)
+                    num_placed_new = num_placed + 1
+
+                    # if !(key_new in visited)
+                    #     parent[key_new] = (key, v)
+                    #     nums_placed[key_new] = num_placed_new
+                    #     enqueue!(queue, key_new)
+                    #     push!(visited, key_new)
+                    # end
+
+                    if num_placed_new == n
+                        ordering = Vector{Int}(undef, n)
+                        ordering[num_placed_new] = v
+                        (key_new, v) = parent[key]
+
+                        while !isnothing(key_new)
+                            ordering[num_placed_new -= 1] = v
+                            (key_new, v) = parent[key_new]
+                        end
+
+                        return ordering
+                    end
+
+                    # if num_placed_new == n
+                    #     ordering = Vector{Int}(undef, n)
+                    #     (key_new, v) = parent[key_new]
+
+                    #     while !isnothing(key_new)
+                    #         ordering[(num_placed_new -= 1) + 1] = v
+                    #         (key_new, v) = parent[key_new]
+                    #     end
+
+                    #     return ordering
+                    # end
+
+                    if !(key_new in visited)
+                        parent[key_new] = (key, v)
+                        nums_placed[key_new] = num_placed_new
+                        enqueue!(queue, key_new)
+                        push!(visited, key_new)
+                    end
+                end
+            end
+        end
+    end
+
     return nothing
 end
 
-function _sgs_connected_ordering(A::AbstractMatrix{Bool}, k::Integer)
-    error("TODO: Not yet implemented")
-    return nothing
+function _sgs_unassigned(
+    region::Vector{Int}, dangling::Set{Tuple{Int,Int}}, adj_lists::Vector{Vector{Int}}
+)
+    if isempty(dangling)
+        return Set(eachindex(adj_lists))
+    end
+
+    unassigned = Set{Int}()
+    processed = Set{Tuple{Int,Int}}(dangling)
+    queue = Queue{Tuple{Int,Int}}()
+    foreach(edge -> enqueue!(queue, edge), dangling)
+    visited = Set(region)
+
+    @inline function _update_state!(node::Int)
+        push!(unassigned, node)
+        push!(visited, node)
+
+        for neighbor in adj_lists[node]
+            edge = _pot_edge(node, neighbor)
+
+            if !(edge in processed)
+                push!(processed, edge)
+                enqueue!(queue, edge)
+            end
+        end
+    end
+
+    while !isempty(queue)
+        (u, v) = dequeue!(queue)
+
+        if !(u in visited)
+            _update_state!(u)
+        elseif !(v in visited)
+            _update_state!(v)
+        end
+    end
+
+    return unassigned
+end
+
+function _sgs_dangling_new(
+    region::Vector{Int}, dangling::Set{Tuple{Int,Int}}, v::Int, adj_list::Vector{Int}
+)
+    neighbors_in_region = Iterators.filter(u -> _pot_edge(u, v) in dangling, region)
+    dangling_new = setdiff(
+        dangling, Iterators.map(u -> _pot_edge(u, v), neighbors_in_region)
+    )
+    additional_edges = Iterators.map(
+        u -> _pot_edge(u, v), Iterators.filter(u -> u != v && !(u in region), adj_list)
+    )
+    return union!(dangling_new, additional_edges)
+end
+
+function _sgs_region_new(
+    region_extended::Vector{Int}, dangling_new::Set{Tuple{Int,Int}}, k::Integer
+)
+    first_idx_in_region = Dict{Int,Int}()
+    foreach(
+        ((i, v),) -> first_idx_in_region[v] = get(first_idx_in_region, v, i),
+        enumerate(region_extended),
+    )
+    region_extended_set = Set(region_extended)
+    active_new = Set(
+        Iterators.filter(in(region_extended_set), Iterators.flatten(dangling_new))
+    )
+
+    if isempty(active_new)
+        region_new = Int[]
+    else
+        extension_size = length(region_extended)
+        pos_min = minimum(Iterators.map(v -> first_idx_in_region[v], active_new))
+
+        if extension_size - pos_min + 1 > k
+            region_new = nothing
+        else
+            region_new = region_extended[pos_min:extension_size]
+        end
+    end
+
+    return region_new
+end
+
+@inline function _sgs_key(region::Vector{Int}, dangling::Set{Tuple{Int,Int}})
+    return (Tuple(region), Tuple(sort!(collect(dangling))))
+end
+
+function _sgs_layout_is_plausible(
+    region::Vector{Int}, dangling::Set{Tuple{Int,Int}}, k::Integer
+)
+    region_size = length(region)
+    nums_dangling = Iterators.map(v -> count(edge -> v in edge, dangling), region)
+    return all(
+        ((num_dangling, idx),) -> num_dangling <= k - region_size + idx,
+        zip(nums_dangling, 1:region_size),
+    )
+end
+
+@inline function _pot_edge(u::Int, v::Int)
+    return (min(u, v), max(u, v))
 end

--- a/src/Recognition/types.jl
+++ b/src/Recognition/types.jl
@@ -14,8 +14,8 @@ As per the interface of supertype [`AbstractAlgorithm`](@ref), concrete subtypes
 `AbstractDecider` must implement the following methods:
 - `Base.summary(::T) where {T<:AbstractDecider}`: returns a `String` indicating the name
     of the decider (e.g., `"Caprara–Salazar-González"`).
-- `_requires_symmetry(::T) where {T<:AbstractDecider}`: returns a `Bool` indicating
-    whether the decider requires the input matrix to be structurally symmetric.
+- `_requires_structural_symmetry(::T) where {T<:AbstractDecider}`: returns a `Bool`
+    indicating whether the decider requires the input matrix to be structurally symmetric.
 
 # Supertype Hierarchy
 `AbstractDecider` <: [`AbstractAlgorithm`](@ref)

--- a/src/types.jl
+++ b/src/types.jl
@@ -13,8 +13,8 @@ Abstract base type for all matrix bandwidth minimization and recognition algorit
 Concrete subtypes of `AbstractAlgorithm` must implement the following methods:
 - `Base.summary(::T) where {T<:AbstractAlgorithm}`: returns a `String` indicating the name
     of the algorithm (e.g., `"Gibbs–Poole–Stockmeyer"`).
-- `_requires_symmetry(::T) where {T<:AbstractAlgorithm}`: returns a `Bool` indicating
-    whether the algorithm requires the input matrix to be structurally symmetric.
+- `_requires_structural_symmetry(::T) where {T<:AbstractAlgorithm}`: returns a `Bool`
+    indicating whether the algorithm requires the input matrix to be structurally symmetric.
 
 Direct subtypes of `AbstractAlgorithm` must implement the following method:
 - `_problem(::T) where {T<:AbstractAlgorithm}`: returns a `Symbol` indicating the
@@ -27,8 +27,8 @@ function Base.summary(::T) where {T<:AbstractAlgorithm}
 end
 
 # Indicate whether the algorithm requires the input matrix to be structurally symmetric
-function _requires_symmetry(::T) where {T<:AbstractAlgorithm}
-    throw(NotImplementedError(_requires_symmetry, T, AbstractAlgorithm))
+function _requires_structural_symmetry(::T) where {T<:AbstractAlgorithm}
+    throw(NotImplementedError(_requires_structural_symmetry, T, AbstractAlgorithm))
 end
 
 #= Indicate the matrix bandwidth problem tackled (e.g., `:minimization`). Each direct

--- a/test/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
+++ b/test/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
@@ -13,8 +13,26 @@ module TestSaxeGurariSudborough
 
 using MatrixBandwidth
 using MatrixBandwidth.Minimization
+using SparseArrays
 using Test
 
-# TODO: Write here
+const MAX_ORDER = 6
+const NUM_ITER = 5
+
+@testset "SGS solver – Brute force verification (n ≤ $MAX_ORDER)" begin
+    for n in 1:MAX_ORDER, _ in 1:NUM_ITER
+        density = rand()
+        A = sprand(n, n, density)
+        A = A + A' # Ensure structural symmetry
+
+        res_bf = minimize_bandwidth(A, BruteForceSearch())
+        res_sgs = minimize_bandwidth(A, SaxeGurariSudborough())
+        ordering_sgs = res_sgs.ordering
+
+        @test res_bf.bandwidth ==
+            res_sgs.bandwidth ==
+            bandwidth(A[ordering_sgs, ordering_sgs])
+    end
+end
 
 end

--- a/test/Recognition/deciders/del_corso_manzini.jl
+++ b/test/Recognition/deciders/del_corso_manzini.jl
@@ -19,7 +19,59 @@ using Test
 const MAX_ORDER = 6
 const NUM_ITER = 5
 
-@testset "DCM decider – Bandwidth < k (n ≤ $MAX_ORDER)" begin
+@testset "DCM decider – Bandwidth ≤ k (n ≤ $MAX_ORDER)" begin
+    for n in 1:MAX_ORDER, _ in 1:NUM_ITER
+        density = rand()
+        A = sprand(n, n, density)
+        A = A + A' # Ensure structural symmetry
+
+        b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
+        k = rand(b:(n - 1))
+
+        res = has_bandwidth_k_ordering(A, k, DelCorsoManzini())
+        ordering = res.ordering
+
+        @test res.has_ordering
+        @test bandwidth(A[ordering, ordering]) <= k
+    end
+end
+
+@testset "DCM-PS decider (default depth) – Bandwidth ≤ k (n ≤ $MAX_ORDER)" begin
+    for n in 1:MAX_ORDER, _ in 1:NUM_ITER
+        density = rand()
+        A = sprand(n, n, density)
+        A = A + A' # Ensure structural symmetry
+
+        b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
+        k = rand(b:(n - 1))
+
+        res = has_bandwidth_k_ordering(A, k, DelCorsoManziniWithPS())
+        ordering = res.ordering
+
+        @test res.has_ordering
+        @test bandwidth(A[ordering, ordering]) <= k
+    end
+end
+
+@testset "DCM-PS decider (custom depth) – Bandwidth ≤ k (n ≤ $MAX_ORDER)" begin
+    for n in 1:MAX_ORDER, _ in 1:NUM_ITER
+        density = rand()
+        A = sprand(n, n, density)
+        A = A + A' # Ensure structural symmetry
+
+        b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
+        k = rand(b:(n - 1))
+        depth = rand(1:n)
+
+        res = has_bandwidth_k_ordering(A, k, DelCorsoManziniWithPS(depth))
+        ordering = res.ordering
+
+        @test res.has_ordering
+        @test bandwidth(A[ordering, ordering]) <= k
+    end
+end
+
+@testset "DCM decider – Bandwidth > k (n ≤ $MAX_ORDER)" begin
     for n in 2:MAX_ORDER, i in 1:NUM_ITER
         density = rand()
         A = sprand(n, n, density)
@@ -41,7 +93,7 @@ const NUM_ITER = 5
     end
 end
 
-@testset "DCM-PS decider (default depth) – Bandwidth < k (n ≤ $MAX_ORDER)" begin
+@testset "DCM-PS decider (default depth) – Bandwidth > k (n ≤ $MAX_ORDER)" begin
     for n in 2:MAX_ORDER, _ in 1:NUM_ITER
         density = rand()
         A = sprand(n, n, density)
@@ -63,7 +115,7 @@ end
     end
 end
 
-@testset "DCM-PS decider (custom depth) – Bandwidth < k (n ≤ $MAX_ORDER)" begin
+@testset "DCM-PS decider (custom depth) – Bandwidth > k (n ≤ $MAX_ORDER)" begin
     for n in 2:MAX_ORDER, _ in 1:NUM_ITER
         density = rand()
         A = sprand(n, n, density)
@@ -83,58 +135,6 @@ end
 
         @test !res.has_ordering
         @test isnothing(res.ordering)
-    end
-end
-
-@testset "DCM decider – Bandwidth ≥ k (n ≤ $MAX_ORDER)" begin
-    for n in 1:MAX_ORDER, _ in 1:NUM_ITER
-        density = rand()
-        A = sprand(n, n, density)
-        A = A + A' # Ensure structural symmetry
-
-        b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
-        k = rand(b:(n - 1))
-
-        res = has_bandwidth_k_ordering(A, k, DelCorsoManzini())
-        ordering = res.ordering
-
-        @test res.has_ordering
-        @test bandwidth(A[ordering, ordering]) <= k
-    end
-end
-
-@testset "DCM-PS decider (default depth) – Bandwidth ≥ k (n ≤ $MAX_ORDER)" begin
-    for n in 1:MAX_ORDER, _ in 1:NUM_ITER
-        density = rand()
-        A = sprand(n, n, density)
-        A = A + A' # Ensure structural symmetry
-
-        b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
-        k = rand(b:(n - 1))
-
-        res = has_bandwidth_k_ordering(A, k, DelCorsoManziniWithPS())
-        ordering = res.ordering
-
-        @test res.has_ordering
-        @test bandwidth(A[ordering, ordering]) <= k
-    end
-end
-
-@testset "DCM-PS decider (custom depth) – Bandwidth ≥ k (n ≤ $MAX_ORDER)" begin
-    for n in 1:MAX_ORDER, _ in 1:NUM_ITER
-        density = rand()
-        A = sprand(n, n, density)
-        A = A + A' # Ensure structural symmetry
-
-        b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
-        k = rand(b:(n - 1))
-        depth = rand(1:n)
-
-        res = has_bandwidth_k_ordering(A, k, DelCorsoManziniWithPS(depth))
-        ordering = res.ordering
-
-        @test res.has_ordering
-        @test bandwidth(A[ordering, ordering]) <= k
     end
 end
 

--- a/test/Recognition/deciders/saxe_gurari_sudborough.jl
+++ b/test/Recognition/deciders/saxe_gurari_sudborough.jl
@@ -13,8 +13,49 @@ module TestSaxeGurariSudborough
 
 using MatrixBandwidth
 using MatrixBandwidth.Recognition
+using SparseArrays
 using Test
 
-# TODO: Write here
+const MAX_ORDER = 6
+const NUM_ITER = 5
+
+@testset "SGS decider – Bandwidth ≤ k (n ≤ $MAX_ORDER)" begin
+    for n in 1:MAX_ORDER, _ in 1:NUM_ITER
+        density = rand()
+        A = sprand(n, n, density)
+        A = A + A' # Ensure structural symmetry
+
+        b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
+        k = rand(b:(n - 1))
+
+        res = has_bandwidth_k_ordering(A, k, SaxeGurariSudborough())
+        ordering = res.ordering
+
+        @test res.has_ordering
+        @test bandwidth(A[ordering, ordering]) <= k
+    end
+end
+
+@testset "SGS decider – Bandwidth > k (n ≤ $MAX_ORDER)" begin
+    for n in 2:MAX_ORDER, _ in 1:NUM_ITER
+        density = rand()
+        A = sprand(n, n, density)
+        A = A + A' # Ensure structural symmetry
+
+        while bandwidth(A) == 0
+            density = rand()
+            A = sprand(n, n, density)
+            A = A + A' # Ensure structural symmetry
+        end
+
+        b = minimize_bandwidth(A, Minimization.BruteForceSearch()).bandwidth
+        k = rand(0:(b - 1))
+
+        res = has_bandwidth_k_ordering(A, k, SaxeGurariSudborough())
+
+        @test !res.has_ordering
+        @test isnothing(res.ordering)
+    end
+end
 
 end


### PR DESCRIPTION
This PR renames the '_requires_symmetry' internal function (used for input validation) to '_requires_structural_symmetry'. It also completes the implementation of the Saxe–Gurari–Sudborough algorithm (both the minimization solver and the recognition decider), although some documentation is still pending. (Unit tests are all complete for SGS, though.)

On a secondary note, it also fixes some test names in the Del Corso–Manzini recognition algorithm test suite ('Bandwidth < k' was meant to be 'Bandwidth > k', and 'Bandwidth ≥ k' was meant to be 'Bandwidth ≤ k').