### PR TITLE
Finish SGS documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Implemented the Saxe&ndash;Gurari&ndash;Sudborough algorithm (both the minimization solver and the recognition decider) (#123). (**NOTE:** Some documentation is still pending.)
+- Implemented the Saxe&ndash;Gurari&ndash;Sudborough algorithm (both the minimization solver and the recognition decider) (#123, #126).
 - Added `bi_criteria_node_finder` (an improvement upon `pseudo_peripheral_node_finder`) as a new node finder for the heuristic solvers (#112).
 - Finished unit tests for all root-level utility functions (#108, #109).
 - Added **References** sections to docstrings for immediate readability in the REPL and in the source code without needing to open the Documenter-generated website (#105).
 
 ### Changed
 
+- Fleshed out and fixed a few typos in the documentation for the Del Corso&ndash;Manzini algorithms (#126).
 - Renamed the `_requires_symmetry` internal function (used for input validation) to `_requires_structural_symmetry` (#123).
 - Reduced the number of iterations and cases in some of the unit tests to cut down on runtime without affecting coverage (#112, #113, #118, #119).
 - Fleshed out documentation (particularly inline comments) for the Gibbs&ndash;Poole&ndash;Stockmeyer source code (#116).

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -47,6 +47,17 @@
   url = {https://apps.dtic.mil/sti/tr/pdf/AD0726171.pdf}
 }
 
+@article{GGJK78,
+  author = {Garey, M. R. and Graham, R. L. and Johnson, D. S. and Knuth, D. E.},
+  journal = {SIAM Journal on Applied Mathematics},
+  number = {3},
+  title = {Complexity Results for Bandwidth Minimization},
+  volume = {34},
+  year = {1978},
+  pages = {477--95},
+  url = {https://doi.org/10.1137/0134037}
+}
+
 @article{GL79,
   author = {George, Alan and Liu, Joseph W. H.},
   journal = {ACM Transactions on Mathematical Software},

--- a/src/Minimization/Exact/solvers/del_corso_manzini.jl
+++ b/src/Minimization/Exact/solvers/del_corso_manzini.jl
@@ -9,13 +9,14 @@
 
 The *Del Corso–Manzini minimization algorithm* is an exact method for minimizing the
 bandwidth of a structurally symmetric matrix ``A``. For a fixed ``k ∈ ℕ``, the algorithm
-performs a depth-first search of all partial orderings of the rows and columns of ``A``,
-adding indices one at a time. Partial orderings are pruned not only by ensuring that
-adjacent pairs of currently placed indices are within ``k`` of each other but also by
-tracking the latest positions at which the remaining indices can be placed. This search is
-repeated with incrementing values of ``k`` until a bandwidth-``k`` ordering is found
-[DM99], with ``k`` initialized to some lower bound on the minimum bandwidth of ``A`` up to
-symmetric permutation.
+invokes a subroutine that determines whether ``A`` has bandwidth at most ``k`` up to
+symmetric permutation. This subroutine performs a depth-first search of all partial
+orderings of the rows and columns of ``A``, adding indices one at a time. Partial orderings
+are pruned not only by ensuring that adjacent pairs of currently placed indices are within
+``k`` of each other but also by tracking the latest positions at which the remaining indices
+can be placed. This search is repeated with incrementing values of ``k`` until a
+bandwidth-``k`` ordering is found [DM99], with ``k`` initialized to some lower bound on the
+minimum bandwidth of ``A`` up to symmetric permutation.
 
 Specifically, this implementation of the Del Corso–Manzini algorithm uses the
 ``min(α(A), γ(A))`` lower bound from [CS05, pp. 359--60] as the initial value of ``k``.
@@ -87,8 +88,8 @@ We now generate (and shuffle) a random ``40×40`` matrix with minimum bandwidth 
 bandwidth-``10`` ordering, which is (we claim) optimal up to symmetric permutation. (In some
 cases, `random_banded_matrix(n, k)` *does* generate matrices with minimum bandwidth `< k`.
 Nevertheless, this example demonstrates that Del Corso–Manzini at the very least finds a
-good ordering, even though exact optimality—which *is* guaranteed by the original paper
-[DM99]—is not explicitly verified.)
+quite good ordering, even though exact optimality—which *is* guaranteed by the original
+paper [DM99]—is not explicitly verified.)
 ```jldoctest
 julia> using Random
 
@@ -251,9 +252,9 @@ We now generate (and shuffle) a random ``30×30`` matrix with minimum bandwidth 
 finds a bandwidth-``8`` ordering, which is (we claim) optimal up to symmetric permutation.
 (In some cases, `random_banded_matrix(n, k)` *does* generate matrices with minimum bandwidth
 `< k`. Nevertheless, this example demonstrates that Del Corso–Manzini at the very least
-finds a good ordering, even though exact optimality—which *is* guaranteed by the original
-paper [DM99]—is not explicitly verified.) In this case, we set the depth parameter to ``4``
-beforehand instead of relying on [`Recognition.dcm_ps_optimal_depth`](@ref).
+finds a quite good ordering, even though exact optimality—which *is* guaranteed by the
+original paper [DM99]—is not explicitly verified.) In this case, we set the depth parameter
+to ``4`` beforehand instead of relying on [`Recognition.dcm_ps_optimal_depth`](@ref).
 
 ```jldoctest
 julia> using Random

--- a/src/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
+++ b/src/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
@@ -7,7 +7,29 @@
 """
     SaxeGurariSudborough <: ExactSolver <: AbstractSolver <: AbstractAlgorithm
 
-[TODO: Write here]
+The *Saxe–Gurari–Sudborough minimization algorithm* is an exact method for minimizing the
+bandwidth of a structurally symmetric matrix ``A``. For a fixed ``k ∈ ℕ``, the algorithm
+invokes a subroutine that determines whether ``A`` has bandwidth at most ``k`` up to
+symmetric permutation. This subroutine employs dynamic programming to search over
+equivalence classes of partial orderings, where two partial orderings of length ``l`` are
+equivalent if they share the same *active region*. (The active region of a partial ordering
+is defined as the sequence of the last ``min(k, l)`` vertices in the ordering taken together
+with all *dangling edges*—edges with one endpoint in the ordering and the other endpoint not
+yet in the ordering.) It extends these partial layouts one vertex at a time in a
+breadth-first manner, pruning implausible classes that violate bandwidth-``k`` constraints
+such as degree bounds on active vertices and excessive numbers of dangling edges [GS84].
+This search is repeated with incrementing values of ``k`` until a bandwidth-``k`` ordering
+is found, with ``k`` initialized to some lower bound on the minimum bandwidth of ``A`` up to
+symmetric permutation.
+
+Specifically, this implementation of the Saxe–Gurari–Sudborough algorithm uses the
+``min(α(A), γ(A))`` lower bound from [CS05, pp. 359--60] as the initial value of ``k``.
+(Further implementation details can be found in the source code for
+[`bandwidth_lower_bound`](@ref).)
+
+As noted above, the Saxe–Gurari–Sudborough algorithm requires structurally symmetric input
+(that is, ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is nonzero for
+``1 ≤ i, j ≤ n``).
 
 # Supertype Hierarchy
 `SaxeGurariSudborough` <: [`ExactSolver`](@ref) <: [`AbstractSolver`](@ref) <: [`MatrixBandwidth.AbstractAlgorithm`](@ref)
@@ -23,10 +45,6 @@ Given an ``n×n`` input matrix ``A``, the Saxe–Gurari–Sudborough algorithm r
     ``O(n)`` times.
 - Therefore, the overall time complexity is ``∑ₖ₌₀ⁿ⁻¹ nᵏ = O(nⁿ⁻¹)``.
 
-# Examples
-[TODO: Write here]
-
-# Notes
 Whereas most exact bandwidth minimization algorithms are technically factorial-time (with
 respect to ``n``) in the worst case but practically always approximate exponential time
 complexity in real life, the ``O(nⁿ⁻¹)`` upper bound on Saxe–Gurari–Sudborough is typically
@@ -35,7 +53,91 @@ algorithms tend to outperform Saxe–Gurari–Sudborough for larger ``n``, given
 aggressive pruning strategies keep their effective search space very small in practice and
 ``O(2ⁿ)`` ⊂ ``O(nⁿ⁻¹)``.
 
+# Examples
+We verify the optimality of the ordering found by Saxe–Gurari–Sudborough for a random
+``9×9`` matrix via a brute-force search over all possible permutations up to reversal:
+```jldoctest
+julia> using Random, SparseArrays
+
+julia> Random.seed!(52452);
+
+julia> (n, p) = (9, 0.5);
+
+julia> A = sprand(n, n, p);
+
+julia> A = A + A' # Ensure structural symmetry;
+
+julia> res_bf = minimize_bandwidth(A, Minimization.BruteForceSearch())
+Results of Bandwidth Minimization Algorithm
+ * Algorithm: Brute-force search
+ * Approach: exact
+ * Minimum Bandwidth: 5
+ * Original Bandwidth: 8
+ * Matrix Size: 9×9
+
+julia> res_sgs = minimize_bandwidth(A, Minimization.SaxeGurariSudborough())
+Results of Bandwidth Minimization Algorithm
+ * Algorithm: Saxe–Gurari–Sudborough
+ * Approach: exact
+ * Minimum Bandwidth: 5
+ * Original Bandwidth: 8
+ * Matrix Size: 9×9
+```
+
+We now generate (and shuffle) a random ``25×25`` matrix with minimum bandwidth ``5`` using
+[`MatrixBandwidth.random_banded_matrix`](@ref). Saxe–Gurari–Sudborough then finds a
+bandwidth-``4`` ordering, which is (we claim) optimal up to symmetric permutation. (In some
+cases, `random_banded_matrix(n, k)` generates matrices with minimum bandwidth `< k`—this
+appears to be one such case. Although we do not explicitly verify exact optimality—which
+*is* guaranteed by the original paper [GS84]—here via brute-force search, this example
+demonstrates that Saxe–Gurari–Sudborough at the very least finds a quite good ordering.)
+```jldoctest
+julia> using Random
+
+julia> Random.seed!(937497);
+
+julia> (n, k, p) = (25, 5, 0.25);
+
+julia> A = random_banded_matrix(n, k; p=p);
+
+julia> perm = randperm(n);
+
+julia> A_shuffled = A[perm, perm];
+
+julia> bandwidth(A)
+5
+
+julia> bandwidth(A_shuffled) # Much larger after shuffling
+19
+
+julia> minimize_bandwidth(A_shuffled, Minimization.SaxeGurariSudborough())
+Results of Bandwidth Minimization Algorithm
+ * Algorithm: Saxe–Gurari–Sudborough
+ * Approach: exact
+ * Minimum Bandwidth: 4
+ * Original Bandwidth: 19
+ * Matrix Size: 25×25
+```
+
+# Notes
+The Saxe–Gurari–Sudborough algorithm was originally a bandwidth recognition algorithm, not a
+minimization one—as previously mentioned, we repurpose it here by repeatedly invoking the
+original procedure for incrementing values of ``k`` until a valid ordering is found. The
+general family of recognition algorithms to which Saxe–Gurari–Sudborough belongs was
+conceived as a response to a question posed by [GGJK78, p. 494]: is the "bandwidth ≤ k?"
+problem NP-complete for arbitrary ``k``? [Sax80] answered this question in the negative by
+providing a ``O(nᵏ⁺¹)`` algorithm, constructively proving that the problem is class P.
+Later, [GS84] improved upon this algorithm by reducing time complexity to ``O(nᵏ)``. Whereas
+the original Saxe algorithm considers extensions of partial orderings with any remaining
+unplaced vertex (of which there are ``O(n)`` at any point in the breadth-first search), the
+Gurari–Sudborough refinement only considers extensions with vertices reachable by paths
+beginning with a dangling edge that never again traverse a dangling edge [GS84, pp.
+535–36].
+
 # References
+- [GGJK78](@cite): M. R. Garey, R. L. Graham, D. S. Johnson and D. E. Knuth. *Complexity
+    Results for Bandwidth Minimization*. SIAM Journal on Applied Mathematics **34**, 477–95
+    (1978). https://doi.org/10.1137/0134037.
 - [GS84](@cite): E. M. Gurari and I. H. Sudborough. *Improved dynamic programming algorithms
     for bandwidth minimization and the MinCut Linear Arrangement problem*. Journal of
     Algorithms **5**, 531–46 (1984). https://doi.org/10.1016/0196-6774(84)90006-3.

--- a/src/Recognition/deciders/del_corso_manzini.jl
+++ b/src/Recognition/deciders/del_corso_manzini.jl
@@ -184,8 +184,8 @@ Results of Bandwidth Recognition Algorithm
 ```
 
 Now, Del Corso–Manzini with perimeter search recognizes that a random ``35×35`` matrix has a
-minimum bandwidth at most ``8``. In this case, we explitily set the depth parameter to ``4``
-beforehand instead of relying on [`Recognition.dcm_ps_optimal_depth`](@ref).
+minimum bandwidth at most ``8``. In this case, we explicitly set the depth parameter to
+``4`` beforehand instead of relying on [`Recognition.dcm_ps_optimal_depth`](@ref).
 ```jldoctest
 julia> using Random, SparseArrays
 

--- a/test/Minimization/Heuristic/solvers/cuthill_mckee.jl
+++ b/test/Minimization/Heuristic/solvers/cuthill_mckee.jl
@@ -126,7 +126,7 @@ end
 vertex degree per connected component as the starting point. We see that
 Gibbs–Poole–Stockmeyer continues to prove effective (although less so) nonetheless. =#
 @testset "RCM solver (naive node finder) – Random matrices (n ≤ $MAX_ORDER)" begin
-    Random.seed!(84664)
+    Random.seed!(84669)
     naive_node_finder =
         A::AbstractMatrix{Bool} -> argmin(i -> sum(view(A, :, i)), axes(A, 1))
 


### PR DESCRIPTION
This PR finishes the documentation for the Saxe–Gurari–Sudborough solver and decider. It also fleshes out some documentation for the Del Corso–Manzini solvers and deciders, and it adjusts a random seed in the unit tests for (reverse) Cuthill–McKee.

(Closes #125.)