### PR TITLE
Replace deprecated 'Queue' methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Replaced all deprecated `DataStructures.enqueue!` and `DataStructures.dequeue!` calls with `Base.push!` and `Base.popfirst!`, respectively ($127).
 - Fleshed out and fixed a few typos in the documentation for the Del Corso&ndash;Manzini algorithms (#126).
 - Renamed the `_requires_symmetry` internal function (used for input validation) to `_requires_structural_symmetry` (#123).
 - Reduced the number of iterations and cases in some of the unit tests to cut down on runtime without affecting coverage (#112, #113, #118, #119).

--- a/src/MatrixBandwidth.jl
+++ b/src/MatrixBandwidth.jl
@@ -72,7 +72,7 @@ The full documentation is available at
 """
 module MatrixBandwidth
 
-using DataStructures: Queue, enqueue!, dequeue!
+using DataStructures: Queue
 using Random
 using PrecompileTools: @setup_workload, @compile_workload
 

--- a/src/Minimization/Heuristic/Heuristic.jl
+++ b/src/Minimization/Heuristic/Heuristic.jl
@@ -37,7 +37,7 @@ import .._connected_components
 import .._approach, .._bool_minimal_band_ordering
 #! format: on
 
-using DataStructures: Queue, enqueue!, dequeue!
+using DataStructures: Queue
 
 export GibbsPooleStockmeyer, CuthillMcKee, ReverseCuthillMcKee
 

--- a/src/Minimization/Heuristic/node_finders.jl
+++ b/src/Minimization/Heuristic/node_finders.jl
@@ -161,16 +161,16 @@ function _farthest!(
     fill!(distances, typemax(Int))
     distances[v] = 0
     empty!(queue)
-    enqueue!(queue, v)
+    push!(queue, v)
 
     while !isempty(queue)
-        curr = dequeue!(queue)
+        curr = popfirst!(queue)
         neighbors = findall(view(A, :, curr))
 
         for neighbor in neighbors
             if distances[neighbor] == typemax(Int)
                 distances[neighbor] = distances[curr] + 1
-                enqueue!(queue, neighbor)
+                push!(queue, neighbor)
             end
         end
     end

--- a/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
+++ b/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
@@ -476,17 +476,17 @@ function _cm_connected_ordering(A::AbstractMatrix{Bool}, node_finder::Function)
 
     start = node_finder(A)
     visited[start] = true
-    enqueue!(queue, start)
+    push!(queue, start)
 
     for i in 1:n
-        parent = dequeue!(queue)
+        parent = popfirst!(queue)
         ordering[i] = parent
 
         unvisited = filter!(node -> !visited[node], findall(view(A, :, parent)))
         sort!(unvisited; by=node -> degrees[node])
 
         visited[unvisited] .= true
-        foreach(neighbor -> enqueue!(queue, neighbor), unvisited)
+        foreach(neighbor -> push!(queue, neighbor), unvisited)
     end
 
     return ordering

--- a/src/Recognition/Recognition.jl
+++ b/src/Recognition/Recognition.jl
@@ -43,7 +43,7 @@ import .._connected_components, .._is_structurally_symmetric, .._offdiag_nonzero
 #! format: on
 
 using Combinatorics: combinations, permutations
-using DataStructures: Queue, enqueue!, dequeue!
+using DataStructures: Queue
 
 # THe output struct and core recognition function
 export RecognitionResult, has_bandwidth_k_ordering

--- a/src/Recognition/deciders/del_corso_manzini.jl
+++ b/src/Recognition/deciders/del_corso_manzini.jl
@@ -494,17 +494,17 @@ function _dcm_lpo_time_stamps(lpo::Vector{Int}, A::AbstractMatrix{Bool}, k::Inte
     foreach(((i, node),) -> time_stamps[node] = n - d + i, enumerate(lpo))
 
     queue = Queue{Int}()
-    foreach(node -> enqueue!(queue, node), lpo)
+    foreach(node -> push!(queue, node), lpo)
 
     #= The nodes processed here are those which are not fixed in the last `d` positions, so
     we compute loose lower bounds on the earliest positions at which they can be placed. =#
     while !isempty(queue)
-        node = dequeue!(queue)
+        node = popfirst!(queue)
         unvisited = filter!(
             neighbor -> time_stamps[neighbor] == 0, findall(view(A, :, node))
         )
         time_stamps[unvisited] .= time_stamps[node] - k
-        foreach(neighbor -> enqueue!(queue, neighbor), unvisited)
+        foreach(neighbor -> push!(queue, neighbor), unvisited)
     end
 
     return time_stamps

--- a/src/Recognition/deciders/saxe_gurari_sudborough.jl
+++ b/src/Recognition/deciders/saxe_gurari_sudborough.jl
@@ -152,11 +152,11 @@ function _sgs_connected_ordering(A::AbstractMatrix{Bool}, k::Integer)
     empty_key = ((), ())
     parent[empty_key] = (nothing, nothing)
     nums_placed[empty_key] = 0
-    enqueue!(queue, empty_key)
+    push!(queue, empty_key)
     push!(visited, empty_key)
 
     while !isempty(queue)
-        key = dequeue!(queue)
+        key = popfirst!(queue)
         num_placed = nums_placed[key]
         region = collect(Int, key[1])
         dangling = Set{Tuple{Int,Int}}(key[2])
@@ -209,7 +209,7 @@ function _sgs_connected_ordering(A::AbstractMatrix{Bool}, k::Integer)
                     if !(key_new in visited)
                         parent[key_new] = (key, v)
                         nums_placed[key_new] = num_placed_new
-                        enqueue!(queue, key_new)
+                        push!(queue, key_new)
                         push!(visited, key_new)
                     end
                 end
@@ -233,7 +233,7 @@ function _sgs_unassigned(
     unassigned = Set{Int}()
     processed = Set{Tuple{Int,Int}}(dangling)
     queue = Queue{Tuple{Int,Int}}()
-    foreach(edge -> enqueue!(queue, edge), dangling)
+    foreach(edge -> push!(queue, edge), dangling)
     visited = Set(region)
 
     @inline function _update_state!(node::Int)
@@ -245,13 +245,13 @@ function _sgs_unassigned(
 
             if !(edge in processed)
                 push!(processed, edge)
-                enqueue!(queue, edge)
+                push!(queue, edge)
             end
         end
     end
 
     while !isempty(queue)
-        (u, v) = dequeue!(queue)
+        (u, v) = popfirst!(queue)
 
         if !(u in visited)
             _update_state!(u)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -155,17 +155,17 @@ function _connected_components(A::AbstractMatrix{Bool})
     for i in 1:n
         if !visited[i]
             visited[i] = true
-            enqueue!(queue, i)
+            push!(queue, i)
             component = Int[]
 
             while !isempty(queue)
-                u = dequeue!(queue)
+                u = popfirst!(queue)
                 push!(component, u)
 
                 for v in findall(view(A, :, u))
                     if !visited[v]
                         visited[v] = true
-                        enqueue!(queue, v)
+                        push!(queue, v)
                     end
                 end
             end


### PR DESCRIPTION
This PR replaces all deprecated 'DataStructures.enqueue!' and 'DataStructures.dequeue!' calls with 'Base.push!' and 'Base.popfirst!', respectively.