### PR TITLE
Speed up GitHub Actions

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,10 @@ const STATIC_ANALYZERS = ["Aqua", "JET"]
 const TEST_GROUPS = ["core", "utils"]
 const NESTED_TEST_SUITES = ["Minimization/Minimization.jl", "Recognition/Recognition.jl"]
 
+if haskey(ENV, "CI")
+    Base.Experimental.suppress_depwarnings(true)
+end
+
 # Run static analysis
 for analyzer in STATIC_ANALYZERS
     @info "Running static analysis with $analyzer"


### PR DESCRIPTION
This PR suppresses depwarns when running tests with the CI.yml workflow. (The repeated deprecation warnings due to outdated DataStructures v0.18 methods on Queue are the cause of much of the slowdown in recent weeks.)