### PR TITLE
Increase number of unit tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 180
+    timeout-minutes: 60
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
       actions: write
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Replaced all deprecated `DataStructures.enqueue!` and `DataStructures.dequeue!` calls with `Base.push!` and `Base.popfirst!`, respectively (#129).
 - Fleshed out and fixed a few typos in the documentation for the Del Corso&ndash;Manzini algorithms (#126).
 - Renamed the `_requires_symmetry` internal function (used for input validation) to `_requires_structural_symmetry` (#123).
-- Reduced the number of iterations and cases in some of the unit tests to cut down on runtime without affecting coverage (#112, #113, #118, #119).
 - Fleshed out documentation (particularly inline comments) for the Gibbs&ndash;Poole&ndash;Stockmeyer source code (#116).
 - Improved unit tests for the heuristic solvers with more edge cases and scenarios (including the use of custom node finders) (#112).
 - Changed the `DEFAULT_NODE_FINDER` constant for the heuristic solvers from `pseudo_peripheral_node_finder` to `bi_criteria_node_finder` (#112).

--- a/test/Minimization/Exact/solvers/del_corso_manzini.jl
+++ b/test/Minimization/Exact/solvers/del_corso_manzini.jl
@@ -17,8 +17,8 @@ using MatrixBandwidth.Minimization
 using SparseArrays
 using Test
 
-const MAX_ORDER = 6
-const NUM_ITER = 5
+const MAX_ORDER = 8
+const NUM_ITER = 10
 
 @testset "DCM solver – Brute force verification (n ≤ $MAX_ORDER)" begin
     for n in 1:MAX_ORDER, _ in 1:NUM_ITER

--- a/test/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
+++ b/test/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
@@ -16,8 +16,8 @@ using MatrixBandwidth.Minimization
 using SparseArrays
 using Test
 
-const MAX_ORDER = 6
-const NUM_ITER = 5
+const MAX_ORDER = 8
+const NUM_ITER = 10
 
 @testset "SGS solver – Brute force verification (n ≤ $MAX_ORDER)" begin
     for n in 1:MAX_ORDER, _ in 1:NUM_ITER

--- a/test/Minimization/Heuristic/solvers/cuthill_mckee.jl
+++ b/test/Minimization/Heuristic/solvers/cuthill_mckee.jl
@@ -21,11 +21,10 @@ using Random
 using SparseArrays
 using Test
 
-const MAX_ORDER = 150
-const MAX_BAND = 15
+const MAX_ORDER = 400
+const MAX_BAND = 20
 const MAX_DENSITY = 0.5
-const MAX_CCS = 3
-const TEST_PROB = 0.3
+const MAX_CCS = 5
 
 include("../test_utils.jl")
 
@@ -60,28 +59,26 @@ bands (pre-shuffling). The default Hou, Liu, and Zhu (2024) node finder is used 
     num_cases = 0
 
     for n in 2:MAX_ORDER
-        if rand() < TEST_PROB # Randomly skip some orders to reduce test time
-            num_ccs = rand(1:min(MAX_CCS, n - 1))
-            k = rand(1:min(MAX_BAND, n - num_ccs))
-            p = MAX_DENSITY * rand()
+        num_ccs = rand(1:min(MAX_CCS, n - 1))
+        k = rand(1:min(MAX_BAND, n - num_ccs))
+        p = MAX_DENSITY * rand()
 
-            A = random_banded_discon_matrix(n, k, num_ccs, p)
-            perm = randperm(n)
-            A = A[perm, perm]
-            res = minimize_bandwidth(A, ReverseCuthillMcKee())
+        A = random_banded_discon_matrix(n, k, num_ccs, p)
+        perm = randperm(n)
+        A = A[perm, perm]
+        res = minimize_bandwidth(A, ReverseCuthillMcKee())
 
-            #= Confirm that the ratio of the minimized bandwidth to the original is not too
-            large. (In some cases, it is possible that the original ordering of `A` is not
-            optimal and that reverse Cuthill–McKee produces an even better one.) =#
-            mult_error = res.bandwidth / k
-            @test mult_error < 3
+        #= Confirm that the ratio of the minimized bandwidth to the original is not too
+        large. (In some cases, it is possible that the original ordering of `A` is not
+        optimal and that reverse Cuthill–McKee produces an even better one.) =#
+        mult_error = res.bandwidth / k
+        @test mult_error < 3
 
-            sum_mult_errors += mult_error
-            num_cases += 1
+        sum_mult_errors += mult_error
+        num_cases += 1
 
-            # Confirm that the ordering computed indeed yields the alleged bandwidth
-            @test bandwidth(A[res.ordering, res.ordering]) == res.bandwidth
-        end
+        # Confirm that the ordering computed indeed yields the alleged bandwidth
+        @test bandwidth(A[res.ordering, res.ordering]) == res.bandwidth
     end
 
     #= We keep track of the average ratio of the minimized bandwidth to the original
@@ -99,24 +96,22 @@ end
     num_cases = 0
 
     for n in 2:MAX_ORDER
-        if rand() < TEST_PROB # Randomly skip some orders to reduce test time
-            num_ccs = rand(1:min(MAX_CCS, n - 1))
-            k = rand(1:min(MAX_BAND, n - num_ccs))
-            p = MAX_DENSITY * rand()
+        num_ccs = rand(1:min(MAX_CCS, n - 1))
+        k = rand(1:min(MAX_BAND, n - num_ccs))
+        p = MAX_DENSITY * rand()
 
-            A = random_banded_discon_matrix(n, k, num_ccs, p)
-            perm = randperm(n)
-            A = A[perm, perm]
-            res = minimize_bandwidth(A, ReverseCuthillMcKee(gl_node_finder))
+        A = random_banded_discon_matrix(n, k, num_ccs, p)
+        perm = randperm(n)
+        A = A[perm, perm]
+        res = minimize_bandwidth(A, ReverseCuthillMcKee(gl_node_finder))
 
-            mult_error = res.bandwidth / k
-            @test mult_error < 3
+        mult_error = res.bandwidth / k
+        @test mult_error < 3
 
-            sum_mult_errors += mult_error
-            num_cases += 1
+        sum_mult_errors += mult_error
+        num_cases += 1
 
-            @test bandwidth(A[res.ordering, res.ordering]) == res.bandwidth
-        end
+        @test bandwidth(A[res.ordering, res.ordering]) == res.bandwidth
     end
 
     @test sum_mult_errors / num_cases < 1.5
@@ -134,24 +129,22 @@ Gibbs–Poole–Stockmeyer continues to prove effective (although less so) nonet
     num_cases = 0
 
     for n in 2:MAX_ORDER
-        if rand() < TEST_PROB # Randomly skip some orders to reduce test time
-            num_ccs = rand(1:min(MAX_CCS, n - 1))
-            k = rand(1:min(MAX_BAND, n - num_ccs))
-            p = MAX_DENSITY * rand()
+        num_ccs = rand(1:min(MAX_CCS, n - 1))
+        k = rand(1:min(MAX_BAND, n - num_ccs))
+        p = MAX_DENSITY * rand()
 
-            A = random_banded_discon_matrix(n, k, num_ccs, p)
-            perm = randperm(n)
-            A = A[perm, perm]
-            res = minimize_bandwidth(A, GibbsPooleStockmeyer(naive_node_finder))
+        A = random_banded_discon_matrix(n, k, num_ccs, p)
+        perm = randperm(n)
+        A = A[perm, perm]
+        res = minimize_bandwidth(A, GibbsPooleStockmeyer(naive_node_finder))
 
-            mult_error = res.bandwidth / k
-            @test mult_error < 3
+        mult_error = res.bandwidth / k
+        @test mult_error < 3
 
-            sum_mult_errors += mult_error
-            num_cases += 1
+        sum_mult_errors += mult_error
+        num_cases += 1
 
-            @test bandwidth(A[res.ordering, res.ordering]) == res.bandwidth
-        end
+        @test bandwidth(A[res.ordering, res.ordering]) == res.bandwidth
     end
 
     @test sum_mult_errors / num_cases < 1.5

--- a/test/Minimization/Heuristic/solvers/gibbs_poole_stockmeyer.jl
+++ b/test/Minimization/Heuristic/solvers/gibbs_poole_stockmeyer.jl
@@ -19,11 +19,10 @@ using Random
 using SparseArrays
 using Test
 
-const MAX_ORDER = 150
-const MAX_BAND = 15
+const MAX_ORDER = 400
+const MAX_BAND = 20
 const MAX_DENSITY = 0.5
-const MAX_CCS = 3
-const TEST_PROB = 0.3
+const MAX_CCS = 5
 
 include("../test_utils.jl")
 
@@ -39,28 +38,26 @@ bands (pre-shuffling). The default Hou, Liu, and Zhu (2024) node finder is used 
     num_cases = 0
 
     for n in 2:MAX_ORDER
-        if rand() < TEST_PROB # Randomly skip some orders to reduce test time
-            num_ccs = rand(1:min(MAX_CCS, n - 1))
-            k = rand(1:min(MAX_BAND, n - num_ccs))
-            p = MAX_DENSITY * rand()
+        num_ccs = rand(1:min(MAX_CCS, n - 1))
+        k = rand(1:min(MAX_BAND, n - num_ccs))
+        p = MAX_DENSITY * rand()
 
-            A = random_banded_discon_matrix(n, k, num_ccs, p)
-            perm = randperm(n)
-            A = A[perm, perm]
-            res = minimize_bandwidth(A, GibbsPooleStockmeyer())
+        A = random_banded_discon_matrix(n, k, num_ccs, p)
+        perm = randperm(n)
+        A = A[perm, perm]
+        res = minimize_bandwidth(A, GibbsPooleStockmeyer())
 
-            #= Confirm that the ratio of the minimized bandwidth to the original is not too
-            large. (In some cases, it is possible that the original ordering of `A` is not
-            not optimal and that Gibbs–Poole–Stockmeyer produces an even better one.) =#
-            mult_error = res.bandwidth / k
-            @test mult_error < 3
+        #= Confirm that the ratio of the minimized bandwidth to the original is not too
+        large. (In some cases, it is possible that the original ordering of `A` is not
+        optimal and that Gibbs–Poole–Stockmeyer produces an even better one.) =#
+        mult_error = res.bandwidth / k
+        @test mult_error < 3
 
-            sum_mult_errors += mult_error
-            num_cases += 1
+        sum_mult_errors += mult_error
+        num_cases += 1
 
-            # Confirm that the ordering computed indeed yields the alleged bandwidth
-            @test bandwidth(A[res.ordering, res.ordering]) == res.bandwidth
-        end
+        # Confirm that the ordering computed indeed yields the alleged bandwidth
+        @test bandwidth(A[res.ordering, res.ordering]) == res.bandwidth
     end
 
     #= We keep track of the average ratio of the minimized bandwidth to the original
@@ -78,24 +75,22 @@ end
     num_cases = 0
 
     for n in 2:MAX_ORDER
-        if rand() < TEST_PROB # Randomly skip some orders to reduce test time
-            num_ccs = rand(1:min(MAX_CCS, n - 1))
-            k = rand(1:min(MAX_BAND, n - num_ccs))
-            p = MAX_DENSITY * rand()
+        num_ccs = rand(1:min(MAX_CCS, n - 1))
+        k = rand(1:min(MAX_BAND, n - num_ccs))
+        p = MAX_DENSITY * rand()
 
-            A = random_banded_discon_matrix(n, k, num_ccs, p)
-            perm = randperm(n)
-            A = A[perm, perm]
-            res = minimize_bandwidth(A, GibbsPooleStockmeyer(gl_node_finder))
+        A = random_banded_discon_matrix(n, k, num_ccs, p)
+        perm = randperm(n)
+        A = A[perm, perm]
+        res = minimize_bandwidth(A, GibbsPooleStockmeyer(gl_node_finder))
 
-            mult_error = res.bandwidth / k
-            @test mult_error < 3
+        mult_error = res.bandwidth / k
+        @test mult_error < 3
 
-            sum_mult_errors += mult_error
-            num_cases += 1
+        sum_mult_errors += mult_error
+        num_cases += 1
 
-            @test bandwidth(A[res.ordering, res.ordering]) == res.bandwidth
-        end
+        @test bandwidth(A[res.ordering, res.ordering]) == res.bandwidth
     end
 
     @test sum_mult_errors / num_cases < 1.5
@@ -113,24 +108,22 @@ Gibbs–Poole–Stockmeyer continues to prove effective (although less so) nonet
     num_cases = 0
 
     for n in 2:MAX_ORDER
-        if rand() < TEST_PROB # Randomly skip some orders to reduce test time
-            num_ccs = rand(1:min(MAX_CCS, n - 1))
-            k = rand(1:min(MAX_BAND, n - num_ccs))
-            p = MAX_DENSITY * rand()
+        num_ccs = rand(1:min(MAX_CCS, n - 1))
+        k = rand(1:min(MAX_BAND, n - num_ccs))
+        p = MAX_DENSITY * rand()
 
-            A = random_banded_discon_matrix(n, k, num_ccs, p)
-            perm = randperm(n)
-            A = A[perm, perm]
-            res = minimize_bandwidth(A, GibbsPooleStockmeyer(naive_node_finder))
+        A = random_banded_discon_matrix(n, k, num_ccs, p)
+        perm = randperm(n)
+        A = A[perm, perm]
+        res = minimize_bandwidth(A, GibbsPooleStockmeyer(naive_node_finder))
 
-            mult_error = res.bandwidth / k
-            @test mult_error < 3
+        mult_error = res.bandwidth / k
+        @test mult_error < 3
 
-            sum_mult_errors += mult_error
-            num_cases += 1
+        sum_mult_errors += mult_error
+        num_cases += 1
 
-            @test bandwidth(A[res.ordering, res.ordering]) == res.bandwidth
-        end
+        @test bandwidth(A[res.ordering, res.ordering]) == res.bandwidth
     end
 
     @test sum_mult_errors / num_cases < 1.5

--- a/test/Recognition/deciders/del_corso_manzini.jl
+++ b/test/Recognition/deciders/del_corso_manzini.jl
@@ -16,8 +16,8 @@ using MatrixBandwidth.Recognition
 using SparseArrays
 using Test
 
-const MAX_ORDER = 6
-const NUM_ITER = 5
+const MAX_ORDER = 8
+const NUM_ITER = 10
 
 @testset "DCM decider – Bandwidth ≤ k (n ≤ $MAX_ORDER)" begin
     for n in 1:MAX_ORDER, _ in 1:NUM_ITER

--- a/test/Recognition/deciders/saxe_gurari_sudborough.jl
+++ b/test/Recognition/deciders/saxe_gurari_sudborough.jl
@@ -16,8 +16,8 @@ using MatrixBandwidth.Recognition
 using SparseArrays
 using Test
 
-const MAX_ORDER = 6
-const NUM_ITER = 5
+const MAX_ORDER = 8
+const NUM_ITER = 10
 
 @testset "SGS decider – Bandwidth ≤ k (n ≤ $MAX_ORDER)" begin
     for n in 1:MAX_ORDER, _ in 1:NUM_ITER

--- a/test/core.jl
+++ b/test/core.jl
@@ -17,14 +17,12 @@ using Graphs
 using SparseArrays
 using Test
 
-const MAX_ORDER1 = 80
-const NUM_ITER1 = 50
-
+const MAX_ORDER1 = 100
 const MAX_ORDER2 = 8
-const NUM_ITER2 = 5
+const NUM_ITER = 10
 
 @testset "`bandwidth` (n ≤ $MAX_ORDER1)" begin
-    for n in 1:MAX_ORDER1, _ in 1:NUM_ITER1
+    for n in 1:MAX_ORDER1, _ in 1:NUM_ITER
         density = rand()
         A = sprand(n, n, density)
 
@@ -35,7 +33,7 @@ const NUM_ITER2 = 5
 end
 
 @testset "`profile` (n ≤ $MAX_ORDER1)" begin
-    for n in 1:MAX_ORDER1, _ in 1:NUM_ITER1
+    for n in 1:MAX_ORDER1, _ in 1:NUM_ITER
         density = rand()
         A = sprand(n, n, density)
 
@@ -73,7 +71,7 @@ end
 end
 
 @testset "`bandwidth_lower_bound` (n ≤ $MAX_ORDER2)" begin
-    for n in 1:MAX_ORDER2, _ in 1:NUM_ITER2
+    for n in 1:MAX_ORDER2, _ in 1:NUM_ITER
         density = rand()
         A = sprand(n, n, density)
         A = A + A' # Ensure structural symmetry
@@ -86,7 +84,7 @@ end
 end
 
 @testset "`_floyd_warshall_shortest_paths` (n ≤ $MAX_ORDER1)" begin
-    for n in 1:MAX_ORDER1, _ in 1:NUM_ITER1
+    for n in 1:MAX_ORDER1, _ in 1:NUM_ITER
         density = rand()
         A = sprand(Bool, n, n, density)
         A = A .|| A' # Ensure structural symmetry

--- a/test/static_analysis/aqua.jl
+++ b/test/static_analysis/aqua.jl
@@ -21,8 +21,16 @@ using Aqua
 
 @testset "Static analysis with Aqua" begin
     @test Test.detect_ambiguities(MatrixBandwidth) == Tuple{Method,Method}[]
-    Aqua.test_all(MatrixBandwidth)
-    @test Aqua.Piracy.hunt(MatrixBandwidth) == Method[]
+    Aqua.test_all(
+        MatrixBandwidth,
+        piracies=(; treat_as_own=[Base.push!, Base.popfirst!]),
+        # Account for our manual definitions of `Base.push!` and `Base.popfirst!`
+        persistent_tasks=false,
+    )
+    #= We manually define the `Base.push!(::Queue, ::Any)` and `Base.popfirst!(::Queue)`
+    methods when using `DataStructures.jl` v0.18, as `enqueue!` and `dequeue!` were only
+    deprecated in v0.19+ and we need to maintain compatibility with v0.18 as well. =#
+    @test length(Aqua.Piracy.hunt(MatrixBandwidth)) <= 2
 end
 
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -17,14 +17,14 @@ using Random
 using SparseArrays
 using Test
 
-const MAX_ORDER = 35
-const CC_NUM_ITER = 5
+const MAX_ORDER = 100
+const CC_NUM_ITER = 10
 const CC_MAX_DENSITY = 0.5
-const CC_MAX_NUM_CCS = 3
+const CC_MAX_NUM_CCS = 5
 const N = 100
 const P = 0.1
 
-@testset "`random_banded_matrix` – Default density" begin
+@testset "`random_banded_matrix` – Default density (n ≤ $MAX_ORDER)" begin
     for n in 1:MAX_ORDER, k in 0:(n - 1)
         A = random_banded_matrix(n, k)
         @test bandwidth(A) == k
@@ -32,7 +32,7 @@ const P = 0.1
     end
 end
 
-@testset "`random_banded_matrix` – Random densities" begin
+@testset "`random_banded_matrix` – Random densities (n ≤ $MAX_ORDER)" begin
     for n in 1:MAX_ORDER, k in 0:(n - 1)
         A = random_banded_matrix(n, k; p=rand())
         @test bandwidth(A) == k
@@ -40,7 +40,7 @@ end
     end
 end
 
-@testset "`random_banded_matrix` – With RNGs" begin
+@testset "`random_banded_matrix` – With RNGs (n ≤ $MAX_ORDER)" begin
     rng = MersenneTwister(228)
 
     for n in 1:MAX_ORDER, k in 0:(n - 1)
@@ -61,7 +61,7 @@ end
     end
 end
 
-@testset "`random_banded_matrix` – Sparse bands" begin
+@testset "`random_banded_matrix` – Sparse bands (n ≤ $MAX_ORDER)" begin
     #= There is essentially zero chance of any nonzero entries beyond the requisite one per
     superdiagonal and subdiagonal up to the `k`ᵗʰ band. =#
     p = 1 / typemax(UInt128)
@@ -79,7 +79,7 @@ end
     end
 end
 
-@testset "`random_banded_matrix` – Full bands" begin
+@testset "`random_banded_matrix` – Full bands (n ≤ $MAX_ORDER)" begin
     p = 1
 
     for n in 1:MAX_ORDER, k in 0:(n - 1)


### PR DESCRIPTION
Previous PRs #112, #113, #118, and #119 reduced the number of iterations and cases in some of the unit tests to cut down on runtime without affecting coverage. This was largely due to a slowdown from thousands of deprecation warnings after the bump to DataStructures v0.19 compat while maintaining backwards compatibility with v0.18. Since #129 fixed this, we now revert back to the old numbers of test iterations and matrix orders, possibly being more robust.

We also reduce the 'timeout-minutes' attribute in our CI.yml workflow back to 60 from 180.