### PR TITLE
Update 'under dev.' flags in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following algorithms are currently supported:
     - Caprara&ndash;Salazar-González algorithm [**under development**]
     - Del Corso&ndash;Manzini algorithm
     - Del Corso&ndash;Manzini algorithm with perimeter search
-    - Saxe&ndash;Gurari&ndash;Sudborough algorithm [**under development**]
+    - Saxe&ndash;Gurari&ndash;Sudborough algorithm
     - Brute-force search
   - *Heuristic*
     - Gibbs&ndash;Poole&ndash;Stockmeyer algorithm
@@ -72,7 +72,7 @@ The following algorithms are currently supported:
   - Caprara&ndash;Salazar-González algorithm [**under development**]
   - Del Corso&ndash;Manzini algorithm
   - Del Corso&ndash;Manzini algorithm with perimeter search
-  - Saxe&ndash;Gurari&ndash;Sudborough algorithm [**under development**]
+  - Saxe&ndash;Gurari&ndash;Sudborough algorithm
   - Brute-force search
 
 (Although the API is already stable with the bulk of the library already functional and tested, a few algorithms remain under development. Whenever such an algorithm is used, the error `ERROR: TODO: Not yet implemented` is raised.)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -62,7 +62,7 @@ The following algorithms are currently supported:
     - Caprara–Salazar-González algorithm [**under development**]
     - Del Corso–Manzini algorithm
     - Del Corso–Manzini algorithm with perimeter search
-    - Saxe–Gurari–Sudborough algorithm [**under development**]
+    - Saxe–Gurari–Sudborough algorithm
     - Brute-force search
   - *Heuristic*
     - Gibbs–Poole–Stockmeyer algorithm
@@ -76,7 +76,7 @@ The following algorithms are currently supported:
   - Caprara–Salazar-González algorithm [**under development**]
   - Del Corso–Manzini algorithm
   - Del Corso–Manzini algorithm with perimeter search
-  - Saxe–Gurari–Sudborough algorithm [**under development**]
+  - Saxe–Gurari–Sudborough algorithm
   - Brute-force search
 
 (Although the API is already stable with the bulk of the library already functional and tested, a few algorithms remain under development. Whenever such an algorithm is used, the error `ERROR: TODO: Not yet implemented` is raised.)


### PR DESCRIPTION
This PR removes the 'under development' flags for the SGS solver and decider in the README following the merging of #123 and #126.