### PR TITLE
Refactor import structure; update exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- [IN PROGRESS] Implementing the Caprara&ndash;Salazar-Gonz&aacute;lez algorithm (both the minimization solver and the recognition decider), concurrently adding *JuMP.jl* as a notable dependency for integer linear programming (#137, TBD).
+
+### Changed
+
+- Removed the export of `random_banded_matrix` from `MatrixBandwidth` (#140).
+- Exported `AbstractAlgorithm` and `AbstractResult` from `MatrixBandwidth`, and exported their various subtypes from the appropriate submodules (#140).
+- Reformatted the export blocks in each submodule to be more in cohesive, similarly to how *Graphs.jl* does it (#140).
+- Removed the leading underscore from many (but not all) top-level utility functions (also renaming `_offdiag_nonzero_support` to `offdiag_nz_support`), adding docstrings to all of these (#140).
+- Refactored the import structure in submodules to do, e.g., `using MatrixBandwidth` in favor of a bunch of `import ..A, ..B, ..C` statements, similarly to how *Graphs.jl* does it (#140).
+
 ## [0.1.4] - 2025-09-03
 
 ### Added
 
-- Update the module docstring and `README.md` to include a paragraph on the motivation and goals of this package (#131).
+- Updated the module docstring and `README.md` to include a paragraph on the motivation and goals of this package (#131).
 - Implemented the Saxe&ndash;Gurari&ndash;Sudborough algorithm (both the minimization solver and the recognition decider) (#123, #126).
 - Added `bi_criteria_node_finder` (an improvement upon `pseudo_peripheral_node_finder`) as a new node finder for the heuristic solvers (#112).
 - Finished unit tests for all root-level utility functions (#108, #109).

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,6 +2,7 @@
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 MatrixBandwidth = "075aa41b-24fd-4573-b25f-92cae432c0f8"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/src/MatrixBandwidth.jl
+++ b/src/MatrixBandwidth.jl
@@ -115,10 +115,32 @@ include("utils.jl")
 include("types.jl")
 include("core.jl")
 
+export
+    # Submodules
+    Minimization,
+    Recognition,
+
+    # Types
+    AbstractAlgorithm,
+    AbstractResult,
+
+    # Core functions
+    bandwidth,
+    bandwidth_lower_bound,
+    profile,
+
+    # Submodule core functions
+    minimize_bandwidth,
+    has_bandwidth_k_ordering
+
 """
     const ALGORITHMS :: Dict{Symbol, Union{Dict{Symbol}, Vector}}
 
 A dictionary indexing the data types of all available algorithms by submodule.
+
+For instance, to access all metaheuristic minimization algorithms, use
+`MatrixBandwidth.ALGORITHMS[:Minimization][:Metaheuristic]`. Similarly, to access all
+recognition algorithms, use `MatrixBandwidth.ALGORITHMS[:Recognition]`.
 """
 const ALGORITHMS = Dict{Symbol,Union{Dict{Symbol},Vector}}()
 
@@ -128,25 +150,5 @@ include("Minimization/Minimization.jl")
 using .Minimization, .Recognition
 
 include("startup.jl")
-
-#= Module exports: allows users to call solvers like `Minimization.GibbsPooleStockmeyer` and
-deciders `like Recognition.CapraraSalazarGonzalez`. Solvers/deciders are not exported at the
-top level due to name conflicts between `Minimization` and `Recognition`. =#
-export Minimization, Recognition
-
-#= Core exports:
-- Compute the original bandwidth (before any reordering).
-- Compute Caprara and Salazar-González (2005)'s lower bound on bandwidth in `O(n³)`. (This
-    bound is tight in many non-trivial cases but not universally so.)
-- Compute the original profile (before any reordering).
-=#
-export bandwidth, bandwidth_lower_bound, profile
-
-#= `Minimization` and `Recognition` exports: the core bandwidth minimization and recognition
-functions. =#
-export minimize_bandwidth, has_bandwidth_k_ordering
-
-# Utility exports: just a random banded matrix generator for now. Useful for test data.
-export random_banded_matrix
 
 end

--- a/src/Minimization/Exact/Exact.jl
+++ b/src/Minimization/Exact/Exact.jl
@@ -28,23 +28,30 @@ This submodule is part of the `MatrixBandwidth.Minimization` submodule of the
 """
 module Exact
 
-#! format: off
-import ..Recognition
-import ..ALGORITHMS
-import ..AbstractSolver
-import ..NotImplementedError, ..StructuralAsymmetryError
-import ..bandwidth, ..bandwidth_lower_bound
-import .._requires_structural_symmetry
-import .._connected_components
-import .._approach, .._bool_minimal_band_ordering
-#! format: on
+using MatrixBandwidth
+using MatrixBandwidth: NotImplementedError, StructuralAsymmetryError
+using MatrixBandwidth: connected_components
+using MatrixBandwidth: _requires_structural_symmetry
+
+using MatrixBandwidth.Recognition
+
+using MatrixBandwidth.Minimization
+using MatrixBandwidth.Minimization: _approach, _bool_minimal_band_ordering
 
 using Combinatorics
 
-export CapraraSalazarGonzalez,
-    DelCorsoManzini, DelCorsoManziniWithPS, SaxeGurariSudborough, BruteForceSearch
+export
+    # Types
+    ExactSolver,
 
-ALGORITHMS[:Minimization][:Exact] = []
+    # Exact solvers
+    CapraraSalazarGonzalez,
+    DelCorsoManzini,
+    DelCorsoManziniWithPS,
+    SaxeGurariSudborough,
+    BruteForceSearch
+
+MatrixBandwidth.ALGORITHMS[:Minimization][:Exact] = []
 
 include("types.jl")
 

--- a/src/Minimization/Exact/solvers/brute_force_search.jl
+++ b/src/Minimization/Exact/solvers/brute_force_search.jl
@@ -64,13 +64,15 @@ would take over an hour.
 """
 struct BruteForceSearch <: ExactSolver end
 
-push!(ALGORITHMS[:Minimization][:Exact], BruteForceSearch)
+push!(MatrixBandwidth.ALGORITHMS[:Minimization][:Exact], BruteForceSearch)
 
 Base.summary(::BruteForceSearch) = "Brute-force search"
 
-_requires_structural_symmetry(::BruteForceSearch) = false
+MatrixBandwidth._requires_structural_symmetry(::BruteForceSearch) = false
 
-function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::BruteForceSearch)
+function Minimization._bool_minimal_band_ordering(
+    A::AbstractMatrix{Bool}, ::BruteForceSearch
+)
     #= `i₁, i₂, … iₙ` induces the same bandwidth as `iₙ, iₙ₋₁, … i₁`, so without loss of
     generality, we restrict our search to orderings such that `i₁ ≤ iₙ` (with equality
     checked just in case `n = 1`). =#

--- a/src/Minimization/Exact/solvers/caprara_salazar_gonzalez.jl
+++ b/src/Minimization/Exact/solvers/caprara_salazar_gonzalez.jl
@@ -43,13 +43,15 @@ As noted above, the Caprara–Salazar-González algorithm requires structurally 
 """
 struct CapraraSalazarGonzalez <: ExactSolver end
 
-# push!(ALGORITHMS[:Minimization][:Exact], CapraraSalazarGonzalez)
+# push!(MatrixBandwidth.ALGORITHMS[:Minimization][:Exact], CapraraSalazarGonzalez)
 
 Base.summary(::CapraraSalazarGonzalez) = "Caprara–Salazar-González"
 
-_requires_structural_symmetry(::CapraraSalazarGonzalez) = true
+MatrixBandwidth._requires_structural_symmetry(::CapraraSalazarGonzalez) = true
 
-function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::CapraraSalazarGonzalez)
+function Minimization._bool_minimal_band_ordering(
+    A::AbstractMatrix{Bool}, ::CapraraSalazarGonzalez
+)
     error("TODO: Not yet implemented")
     return nothing
 end

--- a/src/Minimization/Exact/solvers/del_corso_manzini.jl
+++ b/src/Minimization/Exact/solvers/del_corso_manzini.jl
@@ -32,8 +32,7 @@ is, ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is nonzero for ``1 �
 `DelCorsoManzini` <: [`ExactSolver`](@ref) <: [`AbstractSolver`](@ref) <: [`MatrixBandwidth.AbstractAlgorithm`](@ref)
 
 # Performance
-Given an ``n×n`` input matrix ``A``, the Del Corso–Manzini algorithm runs in
-``O(n! ⋅ n³)`` time:
+Given an ``n×n`` input matrix, the Del Corso–Manzini algorithm runs in ``O(n! ⋅ n³)`` time:
 - For each underlying "bandwidth ≤ ``k``" check, we perform a depth-first search of
     ``O(n!)`` partial orderings.
 - Checking plausibility of each partial ordering takes ``O(nk)`` time, resulting in
@@ -97,7 +96,7 @@ julia> Random.seed!(0201);
 
 julia> (n, k) = (40, 10);
 
-julia> A = random_banded_matrix(n, k);
+julia> A = MatrixBandwidth.random_banded_matrix(n, k);
 
 julia> perm = randperm(n);
 
@@ -133,11 +132,11 @@ on the other hand, we implement in [`DelCorsoManziniWithPS`](@ref).
 """
 struct DelCorsoManzini <: ExactSolver end
 
-push!(ALGORITHMS[:Minimization][:Exact], DelCorsoManzini)
+push!(MatrixBandwidth.ALGORITHMS[:Minimization][:Exact], DelCorsoManzini)
 
 Base.summary(::DelCorsoManzini) = "Del Corso–Manzini"
 
-_requires_structural_symmetry(::DelCorsoManzini) = true
+MatrixBandwidth._requires_structural_symmetry(::DelCorsoManzini) = true
 
 """
     DelCorsoManziniWithPS{D} <: ExactSolver <: AbstractSolver <: AbstractAlgorithm
@@ -191,7 +190,7 @@ nonzero for ``1 ≤ i, j ≤ n``).
 `DelCorsoManziniWithPS` <: [`ExactSolver`](@ref) <: [`AbstractSolver`](@ref) <: [`MatrixBandwidth.AbstractAlgorithm`](@ref)
 
 # Performance
-Given an ``n×n`` input matrix ``A`` and perimeter search depth ``d``, the Del Corso–Manzini
+Given an ``n×n`` input matrix and perimeter search depth ``d``, the Del Corso–Manzini
 algorithm with perimeter search runs in ``O(n! ⋅ nᴰ⁺¹)`` time, where ``Dᴰ = max(d, 2)``:
 - For each underlying "bandwidth ≤ ``k``" check, we perform a depth-first search of
     ``O(n!)`` partial orderings.
@@ -263,7 +262,7 @@ julia> Random.seed!(78779);
 
 julia> (n, k, depth) = (30, 8, 4);
 
-julia> A = random_banded_matrix(n, k);
+julia> A = MatrixBandwidth.random_banded_matrix(n, k);
 
 julia> perm = randperm(n);
 
@@ -315,13 +314,15 @@ struct DelCorsoManziniWithPS{D<:Union{Nothing,Integer}} <: ExactSolver
     end
 end
 
-push!(ALGORITHMS[:Minimization][:Exact], DelCorsoManziniWithPS)
+push!(MatrixBandwidth.ALGORITHMS[:Minimization][:Exact], DelCorsoManziniWithPS)
 
 Base.summary(::DelCorsoManziniWithPS) = "Del Corso–Manzini with perimeter search"
 
-_requires_structural_symmetry(::DelCorsoManziniWithPS) = true
+MatrixBandwidth._requires_structural_symmetry(::DelCorsoManziniWithPS) = true
 
-function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::DelCorsoManzini)
+function Minimization._bool_minimal_band_ordering(
+    A::AbstractMatrix{Bool}, ::DelCorsoManzini
+)
     n = size(A, 1)
 
     ordering_buf = Vector{Int}(undef, n)
@@ -356,7 +357,7 @@ function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::DelCorsoManzini)
     return ordering
 end
 
-function _bool_minimal_band_ordering(
+function Minimization._bool_minimal_band_ordering(
     A::AbstractMatrix{Bool}, solver::DelCorsoManziniWithPS{Nothing}
 )
     #= We cannot compute a (hopefully) near-optimal perimeter search depth upon
@@ -365,7 +366,7 @@ function _bool_minimal_band_ordering(
     return _bool_minimal_band_ordering(A, solver_with_depth)
 end
 
-function _bool_minimal_band_ordering(
+function Minimization._bool_minimal_band_ordering(
     A::AbstractMatrix{Bool}, solver::DelCorsoManziniWithPS{Integer}
 )
     n = size(A, 1)

--- a/src/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
+++ b/src/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
@@ -35,8 +35,8 @@ As noted above, the Saxe–Gurari–Sudborough algorithm requires structurally s
 `SaxeGurariSudborough` <: [`ExactSolver`](@ref) <: [`AbstractSolver`](@ref) <: [`MatrixBandwidth.AbstractAlgorithm`](@ref)
 
 # Performance
-Given an ``n×n`` input matrix ``A``, the Saxe–Gurari–Sudborough algorithm runs in
-``O(nⁿ⁻¹)`` time:
+Given an ``n×n`` input matrix, the Saxe–Gurari–Sudborough algorithm runs in ``O(nⁿ⁻¹)``
+time:
 - For each underlying "bandwidth ≤ k" check, we call the Saxe–Gurari–Sudborough recognition
   algorithm, which runs in ``O(nᵏ)`` time [GS84, p. 531]. (This is an improvement upon the
   original ``O(nᵏ⁺¹)`` Saxe algorithm [Sax80, p. 363].)
@@ -98,7 +98,7 @@ julia> Random.seed!(937497);
 
 julia> (n, k, p) = (25, 5, 0.25);
 
-julia> A = random_banded_matrix(n, k; p=p);
+julia> A = MatrixBandwidth.random_banded_matrix(n, k; p=p);
 
 julia> perm = randperm(n);
 
@@ -147,14 +147,16 @@ beginning with a dangling edge that never again traverse a dangling edge [GS84, 
 """
 struct SaxeGurariSudborough <: ExactSolver end
 
-push!(ALGORITHMS[:Minimization][:Exact], SaxeGurariSudborough)
+push!(MatrixBandwidth.ALGORITHMS[:Minimization][:Exact], SaxeGurariSudborough)
 
 Base.summary(::SaxeGurariSudborough) = "Saxe–Gurari–Sudborough"
 
-_requires_structural_symmetry(::SaxeGurariSudborough) = true
+MatrixBandwidth._requires_structural_symmetry(::SaxeGurariSudborough) = true
 
-function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, ::SaxeGurariSudborough)
-    components = _connected_components(A)
+function Minimization._bool_minimal_band_ordering(
+    A::AbstractMatrix{Bool}, ::SaxeGurariSudborough
+)
+    components = connected_components(A)
     #= Heuristically, it is likelier that smaller components have lower bandwidth, so we
     process them first to keep `k` low for as long as possible (since the complexity of each
     recognition subroutine is exponential in `k`). =#

--- a/src/Minimization/Exact/types.jl
+++ b/src/Minimization/Exact/types.jl
@@ -21,4 +21,4 @@ solutions are required for small-to-medium-sized inputs (say, up to ``100×100``
 """
 abstract type ExactSolver <: AbstractSolver end
 
-_approach(::ExactSolver) = :exact
+Minimization._approach(::ExactSolver) = :exact

--- a/src/Minimization/Heuristic/Heuristic.jl
+++ b/src/Minimization/Heuristic/Heuristic.jl
@@ -28,20 +28,26 @@ This submodule is part of the `MatrixBandwidth.Minimization` submodule of the
 """
 module Heuristic
 
-#! format: off
-import ..ALGORITHMS
-import ..AbstractSolver
-import ..NotImplementedError, ..StructuralAsymmetryError
-import .._requires_structural_symmetry
-import .._connected_components
-import .._approach, .._bool_minimal_band_ordering
-#! format: on
+using MatrixBandwidth
+using MatrixBandwidth: NotImplementedError, StructuralAsymmetryError
+using MatrixBandwidth: connected_components
+using MatrixBandwidth: _requires_structural_symmetry
+
+using MatrixBandwidth.Minimization
+using MatrixBandwidth.Minimization: _approach, _bool_minimal_band_ordering
 
 using DataStructures: Queue
 
-export GibbsPooleStockmeyer, CuthillMcKee, ReverseCuthillMcKee
+export
+    # Types
+    HeuristicSolver,
 
-ALGORITHMS[:Minimization][:Heuristic] = []
+    # Heuristic solvers
+    GibbsPooleStockmeyer,
+    CuthillMcKee,
+    ReverseCuthillMcKee
+
+MatrixBandwidth.ALGORITHMS[:Minimization][:Heuristic] = []
 
 include("node_finders.jl")
 include("types.jl")

--- a/src/Minimization/Heuristic/types.jl
+++ b/src/Minimization/Heuristic/types.jl
@@ -23,4 +23,4 @@ find good solutions in a single pass.
 """
 abstract type HeuristicSolver <: AbstractSolver end
 
-_approach(::HeuristicSolver) = :heuristic
+Minimization._approach(::HeuristicSolver) = :heuristic

--- a/src/Minimization/Metaheuristic/Metaheuristic.jl
+++ b/src/Minimization/Metaheuristic/Metaheuristic.jl
@@ -27,17 +27,23 @@ This submodule is part of the `MatrixBandwidth.Minimization` submodule of the
 """
 module Metaheuristic
 
-#! format: off
-import ..ALGORITHMS
-import ..AbstractSolver
-import ..NotImplementedError
-import .._requires_structural_symmetry
-import .._approach, .._bool_minimal_band_ordering
-#! format: on
+using MatrixBandwidth
+using MatrixBandwidth: NotImplementedError
+using MatrixBandwidth: _requires_structural_symmetry
 
-export SimulatedAnnealing, GeneticAlgorithm, GRASP
+using MatrixBandwidth.Minimization
+using MatrixBandwidth.Minimization: _approach, _bool_minimal_band_ordering
 
-ALGORITHMS[:Minimization][:Metaheuristic] = []
+export
+    # Types
+    MetaheuristicSolver,
+
+    # Metaheuristic solvers
+    GRASP,
+    SimulatedAnnealing,
+    GeneticAlgorithm
+
+MatrixBandwidth.ALGORITHMS[:Minimization][:Metaheuristic] = []
 
 include("types.jl")
 

--- a/src/Minimization/Metaheuristic/solvers/genetic_algorithm.jl
+++ b/src/Minimization/Metaheuristic/solvers/genetic_algorithm.jl
@@ -18,13 +18,15 @@ struct GeneticAlgorithm <: MetaheuristicSolver
     # TODO: Define fields and constructor (for default values)
 end
 
-# push!(ALGORITHMS[:Minimization][:Metaheuristic], GeneticAlgorithm)
+# push!(MatrixBandwidth.ALGORITHMS[:Minimization][:Metaheuristic], GeneticAlgorithm)
 
 Base.summary(::GeneticAlgorithm) = "Genetic algorithm"
 
-_requires_structural_symmetry(::GeneticAlgorithm) = false
+MatrixBandwidth._requires_structural_symmetry(::GeneticAlgorithm) = false
 
-function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, solver::GeneticAlgorithm)
+function Minimization._bool_minimal_band_ordering(
+    A::AbstractMatrix{Bool}, solver::GeneticAlgorithm
+)
     error("TODO: Not yet implemented")
     return nothing
 end

--- a/src/Minimization/Metaheuristic/solvers/grasp.jl
+++ b/src/Minimization/Metaheuristic/solvers/grasp.jl
@@ -18,13 +18,13 @@ struct GRASP <: MetaheuristicSolver
     # TODO: Define fields and constructor (for default values)
 end
 
-# push!(ALGORITHMS[:Minimization][:Metaheuristic], GRASP)
+# push!(MatrixBandwidth.ALGORITHMS[:Minimization][:Metaheuristic], GRASP)
 
 Base.summary(::GRASP) = "Greedy randomized adaptive search procedure (GRASP)"
 
-_requires_structural_symmetry(::GRASP) = false
+MatrixBandwidth._requires_structural_symmetry(::GRASP) = false
 
-function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, Solver::GRASP)
+function Minimization._bool_minimal_band_ordering(A::AbstractMatrix{Bool}, Solver::GRASP)
     error("TODO: Not yet implemented")
     return nothing
 end

--- a/src/Minimization/Metaheuristic/solvers/simulated_annealing.jl
+++ b/src/Minimization/Metaheuristic/solvers/simulated_annealing.jl
@@ -24,13 +24,15 @@ struct SimulatedAnnealing <: MetaheuristicSolver
     # TODO: Make constructor with default values
 end
 
-# push!(ALGORITHMS[:Minimization][:Metaheuristic], SimulatedAnnealing)
+# push!(MatrixBandwidth.ALGORITHMS[:Minimization][:Metaheuristic], SimulatedAnnealing)
 
 Base.summary(::SimulatedAnnealing) = "Simulated annealing"
 
-_requires_structural_symmetry(::SimulatedAnnealing) = false
+MatrixBandwidth._requires_structural_symmetry(::SimulatedAnnealing) = false
 
-function _bool_minimal_band_ordering(A::AbstractMatrix{Bool}, solver::SimulatedAnnealing)
+function Minimization._bool_minimal_band_ordering(
+    A::AbstractMatrix{Bool}, solver::SimulatedAnnealing
+)
     error("TODO: Not yet implemented")
     return nothing
 end

--- a/src/Minimization/Metaheuristic/types.jl
+++ b/src/Minimization/Metaheuristic/types.jl
@@ -22,4 +22,4 @@ poor-quality local minima.
 """
 abstract type MetaheuristicSolver <: AbstractSolver end
 
-_approach(::MetaheuristicSolver) = :metaheuristic
+Minimization._approach(::MetaheuristicSolver) = :metaheuristic

--- a/src/Minimization/Minimization.jl
+++ b/src/Minimization/Minimization.jl
@@ -43,18 +43,43 @@ This submodule is part of the
 """
 module Minimization
 
-#! format: off
-import ..Recognition
-import ..ALGORITHMS
-import ..AbstractAlgorithm, ..AbstractResult
-import ..NotImplementedError, ..RectangularMatrixError, ..StructuralAsymmetryError
-import ..bandwidth, ..bandwidth_lower_bound
-import .._requires_structural_symmetry, .._problem
-import .._connected_components,
-    .._find_direct_subtype, .._is_structurally_symmetric, .._offdiag_nonzero_support
-#! format: on
+using MatrixBandwidth
+using MatrixBandwidth: NotImplementedError, RectangularMatrixError, StructuralAsymmetryError
+using MatrixBandwidth:
+    connected_components, is_structurally_symmetric, offdiag_nz_support, find_direct_subtype
+using MatrixBandwidth: _requires_structural_symmetry, _problem
 
-ALGORITHMS[:Minimization] = Dict{Symbol,Vector}()
+export
+    # Types
+    AbstractSolver,
+    MinimizationResult,
+
+    # Submodule types
+    ExactSolver,
+    HeuristicSolver,
+    MetaheuristicSolver,
+
+    # Core functions
+    minimize_bandwidth,
+
+    # Exact solvers
+    CapraraSalazarGonzalez,
+    DelCorsoManzini,
+    DelCorsoManziniWithPS,
+    SaxeGurariSudborough,
+    BruteForceSearch,
+
+    # Heuristic solvers
+    GibbsPooleStockmeyer,
+    CuthillMcKee,
+    ReverseCuthillMcKee,
+
+    # Metaheuristic solvers
+    SimulatedAnnealing,
+    GeneticAlgorithm,
+    GRASP
+
+MatrixBandwidth.ALGORITHMS[:Minimization] = Dict{Symbol,Vector}()
 
 include("types.jl")
 include("core.jl")
@@ -64,16 +89,6 @@ include("Heuristic/Heuristic.jl")
 include("Metaheuristic/Metaheuristic.jl")
 
 using .Exact, .Heuristic, .Metaheuristic
-
-# The output struct and core minimization function
-export MinimizationResult, minimize_bandwidth
-export CapraraSalazarGonzalez, # Exact solvers
-    DelCorsoManzini,
-    DelCorsoManziniWithPS,
-    SaxeGurariSudborough,
-    BruteForceSearch
-export GibbsPooleStockmeyer, CuthillMcKee, ReverseCuthillMcKee # Heuristic solvers
-export SimulatedAnnealing, GeneticAlgorithm, GRASP # Metaheuristic solvers
 
 const DEFAULT_SOLVER = GibbsPooleStockmeyer()
 

--- a/src/Minimization/core.jl
+++ b/src/Minimization/core.jl
@@ -54,14 +54,14 @@ function minimize_bandwidth(
         throw(RectangularMatrixError(A))
     end
 
-    if _requires_structural_symmetry(solver) && !_is_structurally_symmetric(A)
+    if _requires_structural_symmetry(solver) && !is_structurally_symmetric(A)
         throw(StructuralAsymmetryError(A, solver))
     end
 
     #= We are only concerned with which (off-diagonal) entries are nonzero, not the actual
     values. We also set every diagonal entry to `false` for consistency with any algorithms
     that assume an adjacency matrix structure. =#
-    A_bool = _offdiag_nonzero_support(A)
+    A_bool = offdiag_nz_support(A)
 
     bandwidth_orig = bandwidth(A_bool)
 

--- a/src/Minimization/types.jl
+++ b/src/Minimization/types.jl
@@ -26,12 +26,12 @@ Direct subtypes of `AbstractSolver` must implement the following method:
 """
 abstract type AbstractSolver <: AbstractAlgorithm end
 
-_problem(::AbstractSolver) = :minimization
+MatrixBandwidth._problem(::AbstractSolver) = :minimization
 
 #= Indicate the category of solver (e.g., heuristic). Each direct subtype of
 `AbstractSolver` must implement its own `_approach` method. =#
 function _approach(::T) where {T<:AbstractSolver}
-    subtype = _find_direct_subtype(AbstractSolver, T)
+    subtype = find_direct_subtype(AbstractSolver, T)
     throw(NotImplementedError(_approach, subtype, AbstractSolver))
 end
 

--- a/src/Recognition/Recognition.jl
+++ b/src/Recognition/Recognition.jl
@@ -33,27 +33,30 @@ This submodule is part of the
 """
 module Recognition
 
-#! format: off
-import ..ALGORITHMS
-import ..AbstractAlgorithm, ..AbstractResult
-import ..NotImplementedError, ..RectangularMatrixError, ..StructuralAsymmetryError
-import ..bandwidth, ..bandwidth_lower_bound
-import .._problem
-import .._connected_components, .._is_structurally_symmetric, .._offdiag_nonzero_support
-#! format: on
+using MatrixBandwidth
+using MatrixBandwidth: NotImplementedError, RectangularMatrixError, StructuralAsymmetryError
+using MatrixBandwidth: connected_components, is_structurally_symmetric, offdiag_nz_support
+using MatrixBandwidth: _requires_structural_symmetry, _problem
 
 using Combinatorics: combinations, permutations
 using DataStructures: Queue
 
-# THe output struct and core recognition function
-export RecognitionResult, has_bandwidth_k_ordering
-export CapraraSalazarGonzalez, # Recognition algorithms
+export
+    # Types
+    AbstractDecider,
+    RecognitionResult,
+
+    # Core functions
+    has_bandwidth_k_ordering,
+
+    # Deciders
+    CapraraSalazarGonzalez,
     DelCorsoManzini,
     DelCorsoManziniWithPS,
     SaxeGurariSudborough,
     BruteForceSearch
 
-ALGORITHMS[:Recognition] = []
+MatrixBandwidth.ALGORITHMS[:Recognition] = []
 
 include("types.jl")
 include("core.jl")

--- a/src/Recognition/core.jl
+++ b/src/Recognition/core.jl
@@ -59,7 +59,7 @@ function has_bandwidth_k_ordering(
         throw(RectangularMatrixError(A))
     end
 
-    if _requires_structural_symmetry(decider) && !_is_structurally_symmetric(A)
+    if _requires_structural_symmetry(decider) && !is_structurally_symmetric(A)
         throw(StructuralAsymmetryError(A, decider))
     end
 
@@ -73,7 +73,7 @@ function has_bandwidth_k_ordering(
         #= We are only concerned with which (off-diagonal) entries are nonzero, not the actual
         values. We also set every diagonal entry to `false` for consistency with any algorithms
         that assume an adjacency matrix structure. =#
-        A_bool = _offdiag_nonzero_support(A)
+        A_bool = offdiag_nz_support(A)
         ordering = _bool_bandwidth_k_ordering(A_bool, k, decider)
     else
         ordering = nothing

--- a/src/Recognition/deciders/brute_force_search.jl
+++ b/src/Recognition/deciders/brute_force_search.jl
@@ -21,7 +21,7 @@ to check subsequent permutations.
 `BruteForceSearch` <: [`AbstractDecider`](@ref) <: [`AbstractAlgorithm`](@ref)
 
 # Performance
-Given an ``n×n`` input matrix ``A``, this brute-force algorithm runs in ``O(n! ⋅ n²)`` time:
+Given an ``n×n`` input matrix, this brute-force algorithm runs in ``O(n! ⋅ n²)`` time:
 - Up to ``n!/2`` permutations may be checked (except when ``n = 1``, in which case
     ``1! = 1`` permutation is checked). This is, clearly, ``O(n!)``.
 - For each permutation, the [`bandwidth`](@ref) function is called on `view(A, perm, perm)`,
@@ -84,11 +84,11 @@ permutations up to reversal to ensure that the minimum bandwidth is found).
 """
 struct BruteForceSearch <: AbstractDecider end
 
-push!(ALGORITHMS[:Recognition], BruteForceSearch)
+push!(MatrixBandwidth.ALGORITHMS[:Recognition], BruteForceSearch)
 
 Base.summary(::BruteForceSearch) = "Brute-force search"
 
-_requires_structural_symmetry(::BruteForceSearch) = false
+MatrixBandwidth._requires_structural_symmetry(::BruteForceSearch) = false
 
 #= We take advantage of the laziness of `permutations` and `Iterators.filter` to avoid
 iterating over all orderings if a valid one is found early. =#

--- a/src/Recognition/deciders/caprara_salazar_gonzalez.jl
+++ b/src/Recognition/deciders/caprara_salazar_gonzalez.jl
@@ -46,11 +46,11 @@ said minimization algorithm in
 """
 struct CapraraSalazarGonzalez <: AbstractDecider end
 
-# push!(ALGORITHMS[:Recognition], CapraraSalazarGonzalez)
+# push!(MatrixBandwidth.ALGORITHMS[:Recognition], CapraraSalazarGonzalez)
 
 Base.summary(::CapraraSalazarGonzalez) = "Caprara–Salazar-González"
 
-_requires_structural_symmetry(::CapraraSalazarGonzalez) = true
+MatrixBandwidth._requires_structural_symmetry(::CapraraSalazarGonzalez) = true
 
 function _bool_bandwidth_k_ordering(
     A::AbstractMatrix{Bool}, k::Integer, ::CapraraSalazarGonzalez

--- a/src/Recognition/deciders/del_corso_manzini.jl
+++ b/src/Recognition/deciders/del_corso_manzini.jl
@@ -22,7 +22,7 @@ is, ``A[i, j]`` must be nonzero if and only if ``A[j, i]`` is nonzero for ``1 �
 `DelCorsoManzini` <: [`AbstractDecider`](@ref) <: [`AbstractAlgorithm`](@ref)
 
 # Performance
-Given an ``n×n`` input matrix ``A`` and threshold bandwidth ``k``, the Del Corso–Manzini
+Given an ``n×n`` input matrix and threshold bandwidth ``k``, the Del Corso–Manzini
 algorithm runs in ``O(n! ⋅ nk)`` time:
 - We perform a depth-first search of ``O(n!)`` partial orderings.
 - Checking plausibility of each partial ordering takes ``O(nk)`` time.
@@ -37,8 +37,6 @@ Based on experimental results, the algorithm is feasible for ``n×n`` matrices u
 ``n ≈ 100`` or so.
 
 # Examples
-We demonstrate both an affirmative and a negative result for the Del Corso–Manzini
-recognition algorithm on a random ``40×40`` matrix:
 ```jldoctest
 julia> using Random, SparseArrays
 
@@ -91,11 +89,11 @@ the underlying recognition subroutine for MB-PS is implemented in
 """
 struct DelCorsoManzini <: AbstractDecider end
 
-push!(ALGORITHMS[:Recognition], DelCorsoManzini)
+push!(MatrixBandwidth.ALGORITHMS[:Recognition], DelCorsoManzini)
 
 Base.summary(::DelCorsoManzini) = "Del Corso–Manzini"
 
-_requires_structural_symmetry(::DelCorsoManzini) = true
+MatrixBandwidth._requires_structural_symmetry(::DelCorsoManzini) = true
 
 """
     DelCorsoManziniWithPS{D} <: AbstractDecider <: AbstractAlgorithm
@@ -139,9 +137,8 @@ nonzero for ``1 ≤ i, j ≤ n``).
 `DelCorsoManziniWithPS` <: [`AbstractDecider`](@ref) <: [`AbstractAlgorithm`](@ref)
 
 # Performance
-Given an ``n×n`` input matrix ``A``, perimeter search depth ``d``, and threshold bandwidth
-``k``, the Del Corso–Manzini algorithm with perimeter search runs in ``O(n! ⋅ max(nᵈ, nk))``
-time:
+Given an ``n×n`` input matrix, perimeter search depth ``d``, and threshold bandwidth ``k``,
+the Del Corso–Manzini algorithm with perimeter search runs in ``O(n! ⋅ max(nᵈ, nk))`` time:
 - We perform a depth-first search of ``O(n!)`` partial orderings.
 - Checking plausibility of each partial ordering takes ``O(nk)`` time, and checking
     compatibility with all size-``d`` LPOs takes ``O(nᵈ)`` time. Thus, the overall time
@@ -245,11 +242,11 @@ struct DelCorsoManziniWithPS{D<:Union{Nothing,Integer}} <: AbstractDecider
     end
 end
 
-push!(ALGORITHMS[:Recognition], DelCorsoManziniWithPS)
+push!(MatrixBandwidth.ALGORITHMS[:Recognition], DelCorsoManziniWithPS)
 
 Base.summary(::DelCorsoManziniWithPS) = "Del Corso–Manzini with perimeter search"
 
-_requires_structural_symmetry(::DelCorsoManziniWithPS) = true
+MatrixBandwidth._requires_structural_symmetry(::DelCorsoManziniWithPS) = true
 
 """
     dcm_ps_optimal_depth(A) -> Int

--- a/src/Recognition/deciders/saxe_gurari_sudborough.jl
+++ b/src/Recognition/deciders/saxe_gurari_sudborough.jl
@@ -26,10 +26,10 @@ As noted above, the Saxe–Gurari–Sudborough algorithm requires structurally s
 `SaxeGurariSudborough` <: [`AbstractDecider`](@ref) <: [`AbstractAlgorithm`](@ref)
 
 # Performance
-Given an ``n×n`` input matrix ``A`` and threshold bandwidth ``k``, the
-Saxe–Gurari–Sudborough algorithm runs in ``O(nᵏ)`` time [GS84, p. 531]. This is an
-improvement upon the original ``O(nᵏ⁺¹)`` Saxe algorithm [Sax80, p. 363]. (Of course, when
-``k < 3``, then the initial ``O(n³)`` bandwidth lower bound computation performed in all
+Given an ``n×n`` input matrix and threshold bandwidth ``k``, the Saxe–Gurari–Sudborough
+algorithm runs in ``O(nᵏ)`` time [GS84, p. 531]. This is an improvement upon the original
+``O(nᵏ⁺¹)`` Saxe algorithm [Sax80, p. 363]. (Of course, when ``k < 3``, then the initial
+``O(n³)`` bandwidth lower bound computation performed in all
 [`has_bandwidth_k_ordering`](@ref) calls dominates the overall complexity, although the
 constant scaling factor of that subroutine is generally much smaller than that of the
 algorithm proper).
@@ -43,8 +43,6 @@ for larger ``k``, given that their aggressive pruning strategies keep their effe
 space very small in practice.
 
 # Examples
-We demonstrate both an affirmative and a negative result for the Saxe–Gurari–Sudborough
-recognition algorithm on a random ``20×20`` matrix:
 ```jldoctest
 julia> using Random, SparseArrays
 
@@ -99,16 +97,16 @@ that never again traverse a dangling edge [GS84, pp. 535–36].
 """
 struct SaxeGurariSudborough <: AbstractDecider end
 
-push!(ALGORITHMS[:Recognition], SaxeGurariSudborough)
+push!(MatrixBandwidth.ALGORITHMS[:Recognition], SaxeGurariSudborough)
 
 Base.summary(::SaxeGurariSudborough) = "Saxe–Gurari–Sudborough"
 
-_requires_structural_symmetry(::SaxeGurariSudborough) = true
+MatrixBandwidth._requires_structural_symmetry(::SaxeGurariSudborough) = true
 
 function _bool_bandwidth_k_ordering(
     A::AbstractMatrix{Bool}, k::Integer, ::SaxeGurariSudborough
 )
-    components = _connected_components(A)
+    components = connected_components(A)
     #= Smaller components take less time to process, so we do them first to heuristically
     break earlier in some situtations and avoid wasting time on larger components. =#
     sort!(components; by=length)

--- a/src/Recognition/types.jl
+++ b/src/Recognition/types.jl
@@ -22,7 +22,7 @@ As per the interface of supertype [`AbstractAlgorithm`](@ref), concrete subtypes
 """
 abstract type AbstractDecider <: AbstractAlgorithm end
 
-_problem(::AbstractDecider) = :recognition
+MatrixBandwidth._problem(::AbstractDecider) = :recognition
 
 """
     RecognitionResult{A,M,O} <: AbstractResult

--- a/src/startup.jl
+++ b/src/startup.jl
@@ -22,7 +22,7 @@
             has_bandwidth_k_ordering(A, 2, decider_type())
         end
 
-        for solvers in values(ALGORITHMS[:Minimization]), solver_type in solvers
+        for solver_cat in values(ALGORITHMS[:Minimization]), solver_type in solver_cat
             minimize_bandwidth(A, solver_type())
         end
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -7,7 +7,7 @@
 """
     AbstractAlgorithm
 
-Abstract base type for all matrix bandwidth minimization and recognition algorithms.
+Abstract base type for all matrix bandwidth reduction algorithms.
 
 # Interface
 Concrete subtypes of `AbstractAlgorithm` must implement the following methods:
@@ -34,14 +34,14 @@ end
 #= Indicate the matrix bandwidth problem tackled (e.g., `:minimization`). Each direct
 subtype of `AbstractAlgorithm` must implement its own `_problem` method. =#
 function _problem(::T) where {T<:AbstractAlgorithm}
-    subtype = _find_direct_subtype(AbstractAlgorithm, T)
+    subtype = find_direct_subtype(AbstractAlgorithm, T)
     throw(NotImplementedError(_problem, subtype, AbstractAlgorithm))
 end
 
 """
     AbstractResult
 
-Abstract base type for all matrix bandwidth problem results.
+Abstract base type for all matrix bandwidth reduction results.
 
 # Interface
 Concrete subtypes of `AbstractResult` *must* implement parametric types

--- a/test/Minimization/Heuristic/test_utils.jl
+++ b/test/Minimization/Heuristic/test_utils.jl
@@ -76,11 +76,11 @@ const RCM_ANSWERS = [
 Generate a random disconnected `n×n` matrix with bandwidth `k`.
 
 Specifically, this function generates `num_ccs` separate matrices with bandwidth precisely
-`k` using [`random_banded_matrix`](@ref) then combines them into a single block diagonal
-matrix. Treating the resulting matrix as the adjacency of a directed graph, this ensures
-that there are no edges between any of the blocks, guaranteeing that the resultant graph is
-disconnected with at least `num_ccs` connected components. (If any of the blocks themselves
-are disconnected, the graph may have even more than `num_ccs` components.)
+`k` using [`MatrixBandwidth.random_banded_matrix`](@ref) then combines them into a single
+block diagonal matrix. Treating the resulting matrix as the adjacency of a directed graph,
+this ensures that there are no edges between any of the blocks, guaranteeing that the
+resultant graph is disconnected with at least `num_ccs` connected components. (If any of the
+blocks themselves are disconnected, the graph may have even more than `num_ccs` components.)
 
 Since the Cuthill–McKee and reverse Cuthill–McKee algorithms are designed to work on
 connected components (or their matrix representations), this acts as a useful stress test
@@ -145,12 +145,12 @@ function random_banded_discon_matrix(n::Int, k::Int, num_ccs::Int, p::Real)
 
     components = Vector{SparseMatrixCSC{Float64,Int64}}(undef, num_ccs);
     # Ensure that at least one component (arbitrarily, the first) has bandwidth exactly `k`
-    components[1] = sparse(random_banded_matrix(cc_sizes[1], k; p=p));
+    components[1] = sparse(MatrixBandwidth.random_banded_matrix(cc_sizes[1], k; p=p));
 
     for i in 2:num_ccs # Some components may themselves be disconnected
         cc_size = cc_sizes[i]
         cc_band = rand(0:min(k, cc_size - 1));
-        components[i] = sparse(random_banded_matrix(cc_size, cc_band; p=p));
+        components[i] = sparse(MatrixBandwidth.random_banded_matrix(cc_size, cc_band; p=p));
     end
 
     #= This matrix will have bandwidth precisely `k` with multiple connected components,

--- a/test/core.jl
+++ b/test/core.jl
@@ -13,7 +13,6 @@ module TestCore
 
 using MatrixBandwidth
 using MatrixBandwidth.Minimization
-using Graphs
 using SparseArrays
 using Test
 
@@ -80,21 +79,6 @@ end
         res = minimize_bandwidth(A, BruteForceSearch())
 
         @test k <= res.bandwidth
-    end
-end
-
-@testset "`_floyd_warshall_shortest_paths` (n ≤ $MAX_ORDER1)" begin
-    for n in 1:MAX_ORDER1, _ in 1:NUM_ITER
-        density = rand()
-        A = sprand(Bool, n, n, density)
-        A = A .|| A' # Ensure structural symmetry
-        g = Graph(A)
-
-        res_matband = MatrixBandwidth._floyd_warshall_shortest_paths(A)
-        res_graphs = floyd_warshall_shortest_paths(g).dists
-        res_graphs = replace(res_graphs, typemax(Int) => Inf)
-
-        @test res_matband == res_graphs
     end
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -18,7 +18,7 @@ using SparseArrays
 using Test
 
 const MAX_ORDER = 100
-const CC_NUM_ITER = 10
+const NUM_ITER = 10
 const CC_MAX_DENSITY = 0.5
 const CC_MAX_NUM_CCS = 5
 const N = 100
@@ -26,17 +26,17 @@ const P = 0.1
 
 @testset "`random_banded_matrix` – Default density (n ≤ $MAX_ORDER)" begin
     for n in 1:MAX_ORDER, k in 0:(n - 1)
-        A = random_banded_matrix(n, k)
+        A = MatrixBandwidth.random_banded_matrix(n, k)
         @test bandwidth(A) == k
-        @test MatrixBandwidth._is_structurally_symmetric(A)
+        @test MatrixBandwidth.is_structurally_symmetric(A)
     end
 end
 
 @testset "`random_banded_matrix` – Random densities (n ≤ $MAX_ORDER)" begin
     for n in 1:MAX_ORDER, k in 0:(n - 1)
-        A = random_banded_matrix(n, k; p=rand())
+        A = MatrixBandwidth.random_banded_matrix(n, k; p=rand())
         @test bandwidth(A) == k
-        @test MatrixBandwidth._is_structurally_symmetric(A)
+        @test MatrixBandwidth.is_structurally_symmetric(A)
     end
 end
 
@@ -44,20 +44,20 @@ end
     rng = MersenneTwister(228)
 
     for n in 1:MAX_ORDER, k in 0:(n - 1)
-        A = random_banded_matrix(n, k; rng=copy(rng))
-        B = random_banded_matrix(n, k; rng=copy(rng))
+        A = MatrixBandwidth.random_banded_matrix(n, k; rng=copy(rng))
+        B = MatrixBandwidth.random_banded_matrix(n, k; rng=copy(rng))
 
         p = rand()
-        C = random_banded_matrix(n, k; p=p, rng=copy(rng))
-        D = random_banded_matrix(n, k; p=p, rng=copy(rng))
+        C = MatrixBandwidth.random_banded_matrix(n, k; p=p, rng=copy(rng))
+        D = MatrixBandwidth.random_banded_matrix(n, k; p=p, rng=copy(rng))
 
         @test A == B # Test determinism without a density parameter
         @test C == D # Test determinism with a density parameter
 
         # `A == B` and `C == D`, so we only need to test `A` and `C`
         @test bandwidth(A) == bandwidth(C) == k
-        @test MatrixBandwidth._is_structurally_symmetric(A)
-        @test MatrixBandwidth._is_structurally_symmetric(C)
+        @test MatrixBandwidth.is_structurally_symmetric(A)
+        @test MatrixBandwidth.is_structurally_symmetric(C)
     end
 end
 
@@ -67,7 +67,7 @@ end
     p = 1 / typemax(UInt128)
 
     for n in 1:MAX_ORDER, k in 0:(n - 1)
-        A = random_banded_matrix(n, k; p=p)
+        A = MatrixBandwidth.random_banded_matrix(n, k; p=p)
         @test bandwidth(A) == k
 
         for i in 1:k
@@ -83,7 +83,7 @@ end
     p = 1
 
     for n in 1:MAX_ORDER, k in 0:(n - 1)
-        A = random_banded_matrix(n, k; p=p)
+        A = MatrixBandwidth.random_banded_matrix(n, k; p=p)
         @test bandwidth(A) == k
         # All entries within `k` indices of the diagonal should be nonzero
         @test all(
@@ -93,19 +93,19 @@ end
     end
 end
 
-@testset "`_connected_components` – Singleton" begin
+@testset "`connected_components` – Singleton" begin
     singleton = Graph(0)
     adj_singleton = Bool.(adjacency_matrix(singleton))
-    ccs_singleton = MatrixBandwidth._connected_components(adj_singleton)
+    ccs_singleton = MatrixBandwidth.connected_components(adj_singleton)
 
     @test isempty(ccs_singleton)
 end
 
-@testset "`_connected_components` – Empty graphs (n ≤ $MAX_ORDER)" begin
+@testset "`connected_components` – Empty graphs (n ≤ $MAX_ORDER)" begin
     for n in 1:MAX_ORDER
         e_n = Graph(n)
         adj_e_n = Bool.(adjacency_matrix(e_n))
-        ccs_e_n = MatrixBandwidth._connected_components(adj_e_n)
+        ccs_e_n = MatrixBandwidth.connected_components(adj_e_n)
 
         @test length(ccs_e_n) == n
         @test all(cc -> length(cc) == 1, ccs_e_n)
@@ -113,24 +113,24 @@ end
     end
 end
 
-@testset "`_connected_components` – Complete graphs (n ≤ $MAX_ORDER)" begin
+@testset "`connected_components` – Complete graphs (n ≤ $MAX_ORDER)" begin
     for n in 1:MAX_ORDER
         k_n = complete_graph(n)
         adj_k_n = Bool.(adjacency_matrix(k_n))
-        ccs_k_n = MatrixBandwidth._connected_components(adj_k_n)
+        ccs_k_n = MatrixBandwidth.connected_components(adj_k_n)
 
         @test length(ccs_k_n) == 1
         @test sort!(vcat(ccs_k_n...)) == 1:n
     end
 end
 
-@testset "`_connected_components` – Random graphs (n ≤ $MAX_ORDER)" begin
+@testset "`connected_components` – Random graphs (n ≤ $MAX_ORDER)" begin
     Random.seed!(122105)
 
-    for n in 1:MAX_ORDER, _ in 1:CC_NUM_ITER
+    for n in 1:MAX_ORDER, _ in 1:NUM_ITER
         g = erdos_renyi(n, CC_MAX_DENSITY * rand())
         adj_g = Bool.(adjacency_matrix(g))
-        ccs_g = MatrixBandwidth._connected_components(adj_g)
+        ccs_g = MatrixBandwidth.connected_components(adj_g)
         trusted_ccs_g = connected_components(g) # From `Graphs.jl`
 
         @test sort!(map(sort!, ccs_g)) == sort!(map(sort!, trusted_ccs_g))
@@ -139,38 +139,36 @@ end
 
 max_n_next_test = MAX_ORDER * CC_MAX_NUM_CCS
 
-@testset "`_connected_components` – Random disconnected graphs (n ≤ $max_n_next_test)" begin
+@testset "`connected_components` – Random disconnected graphs (n ≤ $max_n_next_test)" begin
     Random.seed!(040307)
 
-    for n in 1:MAX_ORDER, _ in 1:CC_NUM_ITER
+    for n in 1:MAX_ORDER, _ in 1:NUM_ITER
         num_ccs = rand(1:CC_MAX_NUM_CCS)
         gs = map(_ -> erdos_renyi(n, CC_MAX_DENSITY * rand()), 1:num_ccs)
         g = reduce(blockdiag, gs)
-        ccs_g = MatrixBandwidth._connected_components(Bool.(adjacency_matrix(g)))
+        ccs_g = MatrixBandwidth.connected_components(Bool.(adjacency_matrix(g)))
         trusted_ccs_g = connected_components(g) # From `Graphs.jl`
 
         @test sort!(map(sort!, ccs_g)) == sort!(map(sort!, trusted_ccs_g))
     end
 end
 
-@testset "`_find_direct_subtype`" begin
-    abstract type Parent end
+@testset "`floyd_warshall_shortest_paths` (n ≤ $MAX_ORDER)" begin
+    for n in 1:MAX_ORDER, _ in 1:NUM_ITER
+        density = rand()
+        A = sprand(Bool, n, n, density)
+        A = A .|| A' # Ensure structural symmetry
+        g = Graph(A)
 
-    abstract type Child1 <: Parent end
-    abstract type Grandchild1 <: Child1 end
-    struct Grandchild2 <: Child1 end
+        res_matband = MatrixBandwidth.floyd_warshall_shortest_paths(A)
+        res_graphs = Graphs.floyd_warshall_shortest_paths(g).dists
+        res_graphs = replace(res_graphs, typemax(Int) => Inf)
 
-    abstract type Child2 <: Parent end
-    struct Child3 <: Parent end
-
-    @test MatrixBandwidth._find_direct_subtype(Parent, Child1) === Child1
-    @test MatrixBandwidth._find_direct_subtype(Parent, Grandchild1) === Child1
-    @test MatrixBandwidth._find_direct_subtype(Parent, Grandchild2) === Child1
-    @test MatrixBandwidth._find_direct_subtype(Parent, Child2) === Child2
-    @test MatrixBandwidth._find_direct_subtype(Parent, Child3) === Child3
+        @test res_matband == res_graphs
+    end
 end
 
-@testset "`_is_structurally_symmetric`" begin
+@testset "`is_structurally_symmetric`" begin
     rng = MersenneTwister(787)
     A = sprand(rng, N, N, P)
     A = A + A' # Ensure structural symmetry
@@ -181,20 +179,37 @@ end
     )
     B[offdiag_nonzero_idx] = 0 # Break structural symmetry
 
-    @test MatrixBandwidth._is_structurally_symmetric(A)
-    @test !MatrixBandwidth._is_structurally_symmetric(B)
+    @test MatrixBandwidth.is_structurally_symmetric(A)
+    @test !MatrixBandwidth.is_structurally_symmetric(B)
 end
 
-@testset "`_offdiag_nonzero_support`" begin
+@testset "`offdiag_nz_support`" begin
     rng = MersenneTwister(887853)
     A = sprand(rng, N, N, P)
 
-    offdiag_nonzero_idxs = MatrixBandwidth._offdiag_nonzero_support(A)
+    offdiag_nonzero_idxs = MatrixBandwidth.offdiag_nz_support(A)
     offdiag_zero_idxs = (!).(offdiag_nonzero_idxs)
     foreach(i -> offdiag_zero_idxs[i, i] = false, 1:N)
 
     @test all(!iszero, A[offdiag_nonzero_idxs])
     @test iszero(A[offdiag_zero_idxs])
+end
+
+@testset "`find_direct_subtype`" begin
+    abstract type Parent end
+
+    abstract type Child1 <: Parent end
+    abstract type Grandchild1 <: Child1 end
+    struct Grandchild2 <: Child1 end
+
+    abstract type Child2 <: Parent end
+    struct Child3 <: Parent end
+
+    @test MatrixBandwidth.find_direct_subtype(Parent, Child1) === Child1
+    @test MatrixBandwidth.find_direct_subtype(Parent, Grandchild1) === Child1
+    @test MatrixBandwidth.find_direct_subtype(Parent, Grandchild2) === Child1
+    @test MatrixBandwidth.find_direct_subtype(Parent, Child2) === Child2
+    @test MatrixBandwidth.find_direct_subtype(Parent, Child3) === Child3
 end
 
 end


### PR DESCRIPTION
This PR refactors the import structure in submodules to do, e.g., 'using MatrixBandwidth' in favor of a bunch of 'import ..A, ..B, ..C' statements, similarly to how Graphs.jl does it. (On a related note, it also reformats the export blocks in each submodule to be more in cohesive, again following the style of Graphs.jl.)

Additionally, it removes the leading underscore from many (but not all) top-level utility functions (also renaming '_offdiag_nonzero_support' to 'offdiag_nz_support'), adding docstrings to all of these.

Finally, it exports 'AbstractAlgorithm' and 'AbstractResult' from 'MatrixBandwidth', and exports their various subtypes from the appropriate submodules. (At the same time, it removes the export of 'random_banded_matrix' from 'MatrixBandwidth'.)

(Fixes #138.)