### PR TITLE
Add 'bandwidth_lower_bound' check in 'minimize_bandwidth'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Modified `minimize_bandwidth` to skip the algorithm call and simply use the original ordering in all cases when `bandwidth(A) == bandwidth_lower_bound(A)`, not just when `bandwidth(A) == 0` (#143).
 - Removed the export of `random_banded_matrix` from `MatrixBandwidth` (#140).
 - Exported `AbstractAlgorithm` and `AbstractResult` from `MatrixBandwidth`, and exported their various subtypes from the appropriate submodules (#140).
 - Reformatted the export blocks in each submodule to be more in cohesive, similarly to how *Graphs.jl* does it (#140).

--- a/src/Minimization/core.jl
+++ b/src/Minimization/core.jl
@@ -65,9 +65,9 @@ function minimize_bandwidth(
 
     bandwidth_orig = bandwidth(A_bool)
 
-    # If `A` is already diagonal/empty, no possible ordering can improve its bandwidth
-    if bandwidth_orig == 0
-        bandwidth_min = 0
+    # If `A` is already optimally ordered, no ordering can further reduce its bandwidth
+    if bandwidth_orig == bandwidth_lower_bound(A_bool)
+        bandwidth_min = bandwidth_orig
         ordering = collect(axes(A_bool, 1)) # The original ordering
     else
         #= We call the `_bool_minimal_band_ordering` helper function, which is the function


### PR DESCRIPTION
This PR modifies 'minimize_bandwidth' to skip the algorithm call and simply use the original ordering in all cases when 'bandwidth(A) == bandwidth_lower_bound(A)', not just when 'bandwidth(A) == 0'.

(Resolves #142.)