### PR TITLE
Split up index and autodocs blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Split up the `@index` and `@autodocs` blocks in the Documenter-generated website by submodule (#144).
 - Modified `minimize_bandwidth` to skip the algorithm call and simply use the original ordering in all cases when `bandwidth(A) == bandwidth_lower_bound(A)`, not just when `bandwidth(A) == 0` (#143).
 - Removed the export of `random_banded_matrix` from `MatrixBandwidth` (#140).
 - Exported `AbstractAlgorithm` and `AbstractResult` from `MatrixBandwidth`, and exported their various subtypes from the appropriate submodules (#140).

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,8 +28,8 @@ makedocs(;
     plugins=[bib],
     pages=[
         "Home" => "index.md",
-        "Public API" => "public_api.md",
-        "Private API" => "private_api.md",
+        "Public API Documentation" => "public_api.md",
+        "Private API Documentation" => "private_api.md",
     ],
 )
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,6 +2,8 @@
 CurrentModule = MatrixBandwidth
 ```
 
+# MatrixBandwidth.jl
+
 ```@raw html
 <table>
   <tr>
@@ -277,5 +279,38 @@ The latest stable release of *MatrixBandwidth.jl* is v0.1.4. Although several al
 
 ## Index
 
+### `MatrixBandwidth`
+
 ```@index
+Modules = [MatrixBandwidth]
+```
+
+### `MatrixBandwidth.Minimization`
+
+```@index
+Modules = [MatrixBandwidth.Minimization]
+```
+
+### `MatrixBandwidth.Minimization.Exact`
+
+```@index
+Modules = [MatrixBandwidth.Minimization.Exact]
+```
+
+### `MatrixBandwidth.Minimization.Heuristic`
+
+```@index
+Modules = [MatrixBandwidth.Minimization.Heuristic]
+```
+
+### `MatrixBandwidth.Minimization.Metaheuristic`
+
+```@index
+Modules = [MatrixBandwidth.Minimization.Metaheuristic]
+```
+
+### `MatrixBandwidth.Recognition`
+
+```@index
+Modules = [MatrixBandwidth.Recognition]
 ```

--- a/docs/src/private_api.md
+++ b/docs/src/private_api.md
@@ -2,22 +2,52 @@
 CurrentModule = MatrixBandwidth
 ```
 
-# MatrixBandwidth.jl – Private API
+# Private API Documentation
 
 Documentation for [MatrixBandwidth](https://github.com/Luis-Varona/MatrixBandwidth.jl)'s private API.
 
 !!! note
     The following documentation covers only the private API of the package. For public details, see the [public API documentation](public_api.md).
 
+## `MatrixBandwidth`
+
 ```@autodocs
-Modules = [
-    MatrixBandwidth,
-    MatrixBandwidth.Minimization,
-    MatrixBandwidth.Minimization.Exact,
-    MatrixBandwidth.Minimization.Heuristic,
-    MatrixBandwidth.Minimization.Metaheuristic,
-    MatrixBandwidth.Recognition,
-]
+Modules = [MatrixBandwidth]
+Public = false
+```
+
+## `MatrixBandwidth.Minimization`
+
+```@autodocs
+Modules = [MatrixBandwidth.Minimization]
+Public = false
+```
+
+## `MatrixBandwidth.Minimization.Exact`
+
+```@autodocs
+Modules = [MatrixBandwidth.Minimization.Exact]
+Public = false
+```
+
+## `MatrixBandwidth.Minimization.Heuristic`
+
+```@autodocs
+Modules = [MatrixBandwidth.Minimization.Heuristic]
+Public = false
+```
+
+## `MatrixBandwidth.Minimization.Metaheuristic`
+
+```@autodocs
+Modules = [MatrixBandwidth.Minimization.Metaheuristic]
+Public = false
+```
+
+## `MatrixBandwidth.Recognition`
+
+```@autodocs
+Modules = [MatrixBandwidth.Recognition]
 Public = false
 ```
 

--- a/docs/src/public_api.md
+++ b/docs/src/public_api.md
@@ -2,22 +2,52 @@
 CurrentModule = MatrixBandwidth
 ```
 
-# MatrixBandwidth.jl – Public API
+# Public API Documentation
 
 Documentation for [MatrixBandwidth](https://github.com/Luis-Varona/MatrixBandwidth.jl)'s public API.
 
 !!! note
     The following documentation covers only the public API of the package. For internal details, see the [private API documentation](private_api.md).
 
+## `MatrixBandwidth`
+
 ```@autodocs
-Modules = [
-    MatrixBandwidth,
-    MatrixBandwidth.Minimization,
-    MatrixBandwidth.Minimization.Exact,
-    MatrixBandwidth.Minimization.Heuristic,
-    MatrixBandwidth.Minimization.Metaheuristic,
-    MatrixBandwidth.Recognition,
-]
+Modules = [MatrixBandwidth]
+Private = false
+```
+
+## `MatrixBandwidth.Minimization`
+
+```@autodocs
+Modules = [MatrixBandwidth.Minimization]
+Private = false
+```
+
+## `MatrixBandwidth.Minimization.Exact`
+
+```@autodocs
+Modules = [MatrixBandwidth.Minimization.Exact]
+Private = false
+```
+
+## `MatrixBandwidth.Minimization.Heuristic`
+
+```@autodocs
+Modules = [MatrixBandwidth.Minimization.Heuristic]
+Private = false
+```
+
+## `MatrixBandwidth.Minimization.Metaheuristic`
+
+```@autodocs
+Modules = [MatrixBandwidth.Minimization.Metaheuristic]
+Private = false
+```
+
+## `MatrixBandwidth.Recognition`
+
+```@autodocs
+Modules = [MatrixBandwidth.Recognition]
 Private = false
 ```
 


### PR DESCRIPTION
This PR splits up the '@index' and '@autodocs' blocks in the Documenter-generated website by submodule. (Closes #141.)