### PR TITLE
Remove 'Documentation' word from some page names

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,8 +28,8 @@ makedocs(;
     plugins=[bib],
     pages=[
         "Home" => "index.md",
-        "Public API Documentation" => "public_api.md",
-        "Private API Documentation" => "private_api.md",
+        "Public API" => "public_api.md",
+        "Private API" => "private_api.md",
     ],
 )
 


### PR DESCRIPTION
This PR undoes one of the changes from #144 that renamed the Documenter webpage names 'Publiic API' and 'Private API' to 'Public API Documentation' and 'Private API Documentation'.