### PR TITLE
Remove 'using MatrixBandwidth.Minimization' from 'test/core.jl'

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -12,7 +12,6 @@ Test suite for the core API of the *MatrixBandwidth.jl* package.
 module TestCore
 
 using MatrixBandwidth
-using MatrixBandwidth.Minimization
 using SparseArrays
 using Test
 
@@ -76,7 +75,7 @@ end
         A = A + A' # Ensure structural symmetry
 
         k = bandwidth_lower_bound(A)
-        res = minimize_bandwidth(A, BruteForceSearch())
+        res = minimize_bandwidth(A, Minimization.BruteForceSearch())
 
         @test k <= res.bandwidth
     end


### PR DESCRIPTION
This PR removes the 'using MatrixBandwidth.Minimization' statement from the test suite for the top-level core methods, instead opting to explicitly specify 'Minimization.BruteForceSearch()' where needed.