### PR TITLE
Rename impl methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Added instructions to the documentation for extending the interface with new algorithms via `_minimize_bandwidth_impl` and `_has_bandwidth_k_ordering_impl` (#145).
+- Renamed `_bool_minimal_band_ordering` and `_bool_bandwidth_k_ordering` (the functions wherein new algorithm logic is defined) to `_minimize_bandwidth_impl` and `_has_bandwidth_k_ordering_impl`, respectively (#145).
 - Split up the `@index` and `@autodocs` blocks in the Documenter-generated website by submodule (#144).
 - Modified `minimize_bandwidth` to skip the algorithm call and simply use the original ordering in all cases when `bandwidth(A) == bandwidth_lower_bound(A)`, not just when `bandwidth(A) == 0` (#143).
 - Removed the export of `random_banded_matrix` from `MatrixBandwidth` (#140).

--- a/README.md
+++ b/README.md
@@ -49,42 +49,6 @@ On the other hand, the *matrix bandwidth recognition problem* entails determinin
 
 Many algorithms for both problems exist in the literature, but implementations in the open-source ecosystem are scarce, with those that do exist primarily tackling older, less efficient algorithms. This not only makes it difficult for theoretical researchers to benchmark and compare new approaches but also precludes the application of more performant alternatives in real-life industry settings. This package aims to bridge this gap, presenting a unified interface for matrix bandwidth reduction algorithms in Julia. In addition to providing optimized implementations of many existing approaches, *MatrixBandwidth.jl* also allows for easy extensibility should researchers wish to test new ideas, filling a crucial niche in the current research landscape.
 
-## Algorithms
-
-The following algorithms are currently supported:
-
-- **Minimization**
-  - *Exact*
-    - Caprara&ndash;Salazar-González algorithm [**under development**]
-    - Del Corso&ndash;Manzini algorithm
-    - Del Corso&ndash;Manzini algorithm with perimeter search
-    - Saxe&ndash;Gurari&ndash;Sudborough algorithm
-    - Brute-force search
-  - *Heuristic*
-    - Gibbs&ndash;Poole&ndash;Stockmeyer algorithm
-    - Cuthill&ndash;McKee algorithm
-    - Reverse Cuthill&ndash;McKee algorithm
-  - *Metaheuristic*
-    - Greedy randomized adaptive search procedure (GRASP) [**under development**]
-    - Simulated annealing [**under development**]
-    - Genetic algorithm [**under development**]
-- **Recognition**
-  - Caprara&ndash;Salazar-González algorithm [**under development**]
-  - Del Corso&ndash;Manzini algorithm
-  - Del Corso&ndash;Manzini algorithm with perimeter search
-  - Saxe&ndash;Gurari&ndash;Sudborough algorithm
-  - Brute-force search
-
-(Although the API is already stable with the bulk of the library already functional and tested, a few algorithms remain under development. Whenever such an algorithm is used, the error `ERROR: TODO: Not yet implemented` is raised.)
-
-An index of all available algorithms by submodule may also be accessed via the `MatrixBandwidth.ALGORITHMS` constant; simply run the following command in the Julia REPL:
-
-```julia-repl
-julia> MatrixBandwidth.ALGORITHMS
-Dict{Symbol, Union{Dict{Symbol}, Vector}} with 2 entries:
-[...]
-```
-
 ## Installation
 
 The only prerequisite is a working Julia installation (v1.10 or later). First, enter Pkg mode by typing `]` in the Julia REPL, then run the following command:
@@ -228,6 +192,44 @@ julia> profile(A) # Profile prior to any reordering of rows and columns
 ```
 
 (Closely related to bandwidth, the *column profile* of a matrix is the sum of the distances from each diagonal entry to the farthest nonzero entry in that column, whereas the *row profile* is the sum of the distances from each diagonal entry to the farthest nonzero entry in that row. `profile(A)` computes the column profile of `A` by default, but it can also be used to compute the row profile.)
+
+## Algorithms
+
+The following algorithms are currently supported:
+
+- **Minimization**
+  - *Exact*
+    - Caprara&ndash;Salazar-González algorithm [**under development**]
+    - Del Corso&ndash;Manzini algorithm
+    - Del Corso&ndash;Manzini algorithm with perimeter search
+    - Saxe&ndash;Gurari&ndash;Sudborough algorithm
+    - Brute-force search
+  - *Heuristic*
+    - Gibbs&ndash;Poole&ndash;Stockmeyer algorithm
+    - Cuthill&ndash;McKee algorithm
+    - Reverse Cuthill&ndash;McKee algorithm
+  - *Metaheuristic*
+    - Greedy randomized adaptive search procedure (GRASP) [**under development**]
+    - Simulated annealing [**under development**]
+    - Genetic algorithm [**under development**]
+- **Recognition**
+  - Caprara&ndash;Salazar-González algorithm [**under development**]
+  - Del Corso&ndash;Manzini algorithm
+  - Del Corso&ndash;Manzini algorithm with perimeter search
+  - Saxe&ndash;Gurari&ndash;Sudborough algorithm
+  - Brute-force search
+
+(Although the API is already stable with the bulk of the library already functional and tested, a few algorithms remain under development. Whenever such an algorithm is used, the error `ERROR: TODO: Not yet implemented` is raised.)
+
+An index of all available algorithms by submodule may also be accessed via the `MatrixBandwidth.ALGORITHMS` constant; simply run the following command in the Julia REPL:
+
+```julia-repl
+julia> MatrixBandwidth.ALGORITHMS
+Dict{Symbol, Union{Dict{Symbol}, Vector}} with 2 entries:
+[...]
+```
+
+To extend the interface with a new matrix bandwidth minimization algorithm, define a new concrete subtype of `AbstractSolver` (or of one of its abstract subtypes like `MetaheuristicSolver`) then implement a corresponding `Minimization._minimize_bandwidth_impl(::AbstractMatrix{Bool}, ::NewSolverType)` method. Similarly, to implement a new bandwidth recognition algorithm, define a new concrete subtype of `AbstractDecider` then implement a corresponding `Recognition._has_bandwidth_k_ordering_impl(::AbstractMatrix{Bool}, ::Integer, ::NewDeciderType)` method. Do *not* attempt to directly implement new `minimize_bandwidth` or `has_bandwidth_k_ordering` methods, as these functions contain common preprocessing logic independent of the specific algorithm used.
 
 ## Documentation
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,7 +15,7 @@ DocMeta.setdocmeta!(
 bib = CitationBibliography(joinpath(@__DIR__, "src", "refs.bib"); style=:alpha)
 
 makedocs(;
-    modules=[MatrixBandwidth, MatrixBandwidth.Minimization, MatrixBandwidth.Recognition],
+    modules=[MatrixBandwidth],
     authors="Luis M. B. Varona <lm.varona@outlook.com>",
     sitename="MatrixBandwidth.jl",
     format=Documenter.HTML(;

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -55,42 +55,6 @@ On the other hand, the *matrix bandwidth recognition problem* entails determinin
 
 Many algorithms for both problems exist in the literature, but implementations in the open-source ecosystem are scarce, with those that do exist primarily tackling older, less efficient algorithms. This not only makes it difficult for theoretical researchers to benchmark and compare new approaches but also precludes the application of more performant alternatives in real-life industry settings. This package aims to bridge this gap, presenting a unified interface for matrix bandwidth reduction algorithms in Julia. In addition to providing optimized implementations of many existing approaches, *MatrixBandwidth.jl* also allows for easy extensibility should researchers wish to test new ideas, filling a crucial niche in the current research landscape.
 
-## Algorithms
-
-The following algorithms are currently supported:
-
-- **Minimization**
-  - *Exact*
-    - Caprara–Salazar-González algorithm [**under development**]
-    - Del Corso–Manzini algorithm
-    - Del Corso–Manzini algorithm with perimeter search
-    - Saxe–Gurari–Sudborough algorithm
-    - Brute-force search
-  - *Heuristic*
-    - Gibbs–Poole–Stockmeyer algorithm
-    - Cuthill–McKee algorithm
-    - Reverse Cuthill–McKee algorithm
-  - *Metaheuristic*
-    - Greedy randomized adaptive search procedure (GRASP) [**under development**]
-    - Simulated annealing [**under development**]
-    - Genetic algorithm [**under development**]
-- **Recognition**
-  - Caprara–Salazar-González algorithm [**under development**]
-  - Del Corso–Manzini algorithm
-  - Del Corso–Manzini algorithm with perimeter search
-  - Saxe–Gurari–Sudborough algorithm
-  - Brute-force search
-
-(Although the API is already stable with the bulk of the library already functional and tested, a few algorithms remain under development. Whenever such an algorithm is used, the error `ERROR: TODO: Not yet implemented` is raised.)
-
-An index of all available algorithms by submodule may also be accessed via the `MatrixBandwidth.ALGORITHMS` constant; simply run the following command in the Julia REPL:
-
-```julia-repl
-julia> MatrixBandwidth.ALGORITHMS
-Dict{Symbol, Union{Dict{Symbol}, Vector}} with 2 entries:
-[...]
-```
-
 ## Installation
 
 The only prerequisite is a working Julia installation (v1.10 or later). First, enter Pkg mode by typing `]` in the Julia REPL, then run the following command:
@@ -234,6 +198,44 @@ julia> profile(A) # Profile prior to any reordering of rows and columns
 ```
 
 (Closely related to bandwidth, the *column profile* of a matrix is the sum of the distances from each diagonal entry to the farthest nonzero entry in that column, whereas the *row profile* is the sum of the distances from each diagonal entry to the farthest nonzero entry in that row. `profile(A)` computes the column profile of `A` by default, but it can also be used to compute the row profile.)
+
+## Algorithms
+
+The following algorithms are currently supported:
+
+- **Minimization**
+  - *Exact*
+    - Caprara–Salazar-González algorithm [**under development**]
+    - Del Corso–Manzini algorithm
+    - Del Corso–Manzini algorithm with perimeter search
+    - Saxe–Gurari–Sudborough algorithm
+    - Brute-force search
+  - *Heuristic*
+    - Gibbs–Poole–Stockmeyer algorithm
+    - Cuthill–McKee algorithm
+    - Reverse Cuthill–McKee algorithm
+  - *Metaheuristic*
+    - Greedy randomized adaptive search procedure (GRASP) [**under development**]
+    - Simulated annealing [**under development**]
+    - Genetic algorithm [**under development**]
+- **Recognition**
+  - Caprara–Salazar-González algorithm [**under development**]
+  - Del Corso–Manzini algorithm
+  - Del Corso–Manzini algorithm with perimeter search
+  - Saxe–Gurari–Sudborough algorithm
+  - Brute-force search
+
+(Although the API is already stable with the bulk of the library already functional and tested, a few algorithms remain under development. Whenever such an algorithm is used, the error `ERROR: TODO: Not yet implemented` is raised.)
+
+An index of all available algorithms by submodule may also be accessed via the `MatrixBandwidth.ALGORITHMS` constant; simply run the following command in the Julia REPL:
+
+```julia-repl
+julia> MatrixBandwidth.ALGORITHMS
+Dict{Symbol, Union{Dict{Symbol}, Vector}} with 2 entries:
+[...]
+```
+
+To extend the interface with a new matrix bandwidth minimization algorithm, define a new concrete subtype of `AbstractSolver` (or of one of its abstract subtypes like `MetaheuristicSolver`) then implement a corresponding `Minimization._minimize_bandwidth_impl(::AbstractMatrix{Bool}, ::NewSolverType)` method. Similarly, to implement a new bandwidth recognition algorithm, define a new concrete subtype of `AbstractDecider` then implement a corresponding `Recognition._has_bandwidth_k_ordering_impl(::AbstractMatrix{Bool}, ::Integer, ::NewDeciderType)` method. Do *not* attempt to directly implement new `minimize_bandwidth` or `has_bandwidth_k_ordering` methods, as these functions contain common preprocessing logic independent of the specific algorithm used.
 
 ## Documentation
 

--- a/src/Minimization/Exact/Exact.jl
+++ b/src/Minimization/Exact/Exact.jl
@@ -36,7 +36,7 @@ using MatrixBandwidth: _requires_structural_symmetry
 using MatrixBandwidth.Recognition
 
 using MatrixBandwidth.Minimization
-using MatrixBandwidth.Minimization: _approach, _bool_minimal_band_ordering
+using MatrixBandwidth.Minimization: _approach, _minimize_bandwidth_impl
 
 using Combinatorics
 

--- a/src/Minimization/Exact/solvers/brute_force_search.jl
+++ b/src/Minimization/Exact/solvers/brute_force_search.jl
@@ -70,9 +70,7 @@ Base.summary(::BruteForceSearch) = "Brute-force search"
 
 MatrixBandwidth._requires_structural_symmetry(::BruteForceSearch) = false
 
-function Minimization._bool_minimal_band_ordering(
-    A::AbstractMatrix{Bool}, ::BruteForceSearch
-)
+function Minimization._minimize_bandwidth_impl(A::AbstractMatrix{Bool}, ::BruteForceSearch)
     #= `i₁, i₂, … iₙ` induces the same bandwidth as `iₙ, iₙ₋₁, … i₁`, so without loss of
     generality, we restrict our search to orderings such that `i₁ ≤ iₙ` (with equality
     checked just in case `n = 1`). =#

--- a/src/Minimization/Exact/solvers/caprara_salazar_gonzalez.jl
+++ b/src/Minimization/Exact/solvers/caprara_salazar_gonzalez.jl
@@ -49,7 +49,7 @@ Base.summary(::CapraraSalazarGonzalez) = "Caprara–Salazar-González"
 
 MatrixBandwidth._requires_structural_symmetry(::CapraraSalazarGonzalez) = true
 
-function Minimization._bool_minimal_band_ordering(
+function Minimization._minimize_bandwidth_impl(
     A::AbstractMatrix{Bool}, ::CapraraSalazarGonzalez
 )
     error("TODO: Not yet implemented")

--- a/src/Minimization/Exact/solvers/del_corso_manzini.jl
+++ b/src/Minimization/Exact/solvers/del_corso_manzini.jl
@@ -301,8 +301,8 @@ struct DelCorsoManziniWithPS{D<:Union{Nothing,Integer}} <: ExactSolver
 
     #= We cannot compute a (hopefully) near-optimal perimeter search depth upon
     instantiation of the solver, as it depends on the input matrix as well. Hence, we use
-    `nothing` as a sentinel to indicate to `_bool_minimal_band_ordering` that a default
-    depth still needs to be computed upon the function call. =#
+    `nothing` as a sentinel to indicate to `_minimize_bandwidth_impl` that a default depth
+    still needs to be computed upon the function call. =#
     DelCorsoManziniWithPS() = new{Nothing}(nothing)
 
     function DelCorsoManziniWithPS(depth::Integer)
@@ -320,9 +320,7 @@ Base.summary(::DelCorsoManziniWithPS) = "Del Corso–Manzini with perimeter sear
 
 MatrixBandwidth._requires_structural_symmetry(::DelCorsoManziniWithPS) = true
 
-function Minimization._bool_minimal_band_ordering(
-    A::AbstractMatrix{Bool}, ::DelCorsoManzini
-)
+function Minimization._minimize_bandwidth_impl(A::AbstractMatrix{Bool}, ::DelCorsoManzini)
     n = size(A, 1)
 
     ordering_buf = Vector{Int}(undef, n)
@@ -357,16 +355,16 @@ function Minimization._bool_minimal_band_ordering(
     return ordering
 end
 
-function Minimization._bool_minimal_band_ordering(
+function Minimization._minimize_bandwidth_impl(
     A::AbstractMatrix{Bool}, solver::DelCorsoManziniWithPS{Nothing}
 )
     #= We cannot compute a (hopefully) near-optimal perimeter search depth upon
     instantiation of the solver, as it depends on the input matrix as well. =#
     solver_with_depth = DelCorsoManziniWithPS(Recognition.dcm_ps_optimal_depth(A))
-    return _bool_minimal_band_ordering(A, solver_with_depth)
+    return _minimize_bandwidth_impl(A, solver_with_depth)
 end
 
-function Minimization._bool_minimal_band_ordering(
+function Minimization._minimize_bandwidth_impl(
     A::AbstractMatrix{Bool}, solver::DelCorsoManziniWithPS{Integer}
 )
     n = size(A, 1)

--- a/src/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
+++ b/src/Minimization/Exact/solvers/saxe_gurari_sudborough.jl
@@ -153,7 +153,7 @@ Base.summary(::SaxeGurariSudborough) = "Saxe–Gurari–Sudborough"
 
 MatrixBandwidth._requires_structural_symmetry(::SaxeGurariSudborough) = true
 
-function Minimization._bool_minimal_band_ordering(
+function Minimization._minimize_bandwidth_impl(
     A::AbstractMatrix{Bool}, ::SaxeGurariSudborough
 )
     components = connected_components(A)

--- a/src/Minimization/Heuristic/Heuristic.jl
+++ b/src/Minimization/Heuristic/Heuristic.jl
@@ -34,7 +34,7 @@ using MatrixBandwidth: connected_components
 using MatrixBandwidth: _requires_structural_symmetry
 
 using MatrixBandwidth.Minimization
-using MatrixBandwidth.Minimization: _approach, _bool_minimal_band_ordering
+using MatrixBandwidth.Minimization: _approach, _minimize_bandwidth_impl
 
 using DataStructures: Queue
 

--- a/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
+++ b/src/Minimization/Heuristic/solvers/cuthill_mckee.jl
@@ -41,7 +41,7 @@ It was found in [Geo71, pp. 114--15] that reversing the ordering produced by Cut
 tends to induce a more optimal *matrix profile* (a measure of how far, on average, nonzero
 entries are from the diagonal; see also [`MatrixBandwidth.profile`](@ref)). This so-called
 *reverse Cuthill–McKee* variant is preferred in almost all cases—see
-[`ReverseCuthillMcKee`](@ref) and the associated method of `_bool_minimal_band_ordering` for
+[`ReverseCuthillMcKee`](@ref) and the associated method of `_minimize_bandwidth_impl` for
 our implementation.
 
 # Examples
@@ -415,8 +415,8 @@ Note that the `node_finder` field must be of the form `(A::AbstractMatrix{Bool})
 `ArgumentError` is thrown upon construction.
 
 See also the documentation for [`CuthillMcKee`](@ref)—the original (non-reversed) algorithm.
-(Indeed, the reverse Cuthill–McKee method of `_bool_minimal_band_ordering` is merely a
-wrapper around the Cuthill–McKee method.)
+(Indeed, the reverse Cuthill–McKee method of `_minimize_bandwidth_impl` is merely a wrapper
+around the Cuthill–McKee method.)
 
 # References
 - [CG80](@cite): W. M. Chan and A. George. *A linear time implementation of the reverse
@@ -448,7 +448,7 @@ MatrixBandwidth._requires_structural_symmetry(::ReverseCuthillMcKee) = true
 allocating `component_orderings` or individual `component[component_ordering]` arrays.
 (Indeed, the only allocations performed here are those performed by `connected_components`,
 individual `_cm_connected_ordering` calls, and `collect` at the very end.) =#
-function Minimization._bool_minimal_band_ordering(
+function Minimization._minimize_bandwidth_impl(
     A::AbstractMatrix{Bool}, solver::CuthillMcKee
 )
     node_finder = solver.node_finder
@@ -467,10 +467,10 @@ function Minimization._bool_minimal_band_ordering(
     )
 end
 
-function Minimization._bool_minimal_band_ordering(
+function Minimization._minimize_bandwidth_impl(
     A::AbstractMatrix{Bool}, solver::ReverseCuthillMcKee
 )
-    return reverse!(_bool_minimal_band_ordering(A, CuthillMcKee(solver.node_finder)))
+    return reverse!(_minimize_bandwidth_impl(A, CuthillMcKee(solver.node_finder)))
 end
 
 # Cuthill–McKee searches each connected component independently

--- a/src/Minimization/Heuristic/solvers/gibbs_poole_stockmeyer.jl
+++ b/src/Minimization/Heuristic/solvers/gibbs_poole_stockmeyer.jl
@@ -240,7 +240,7 @@ MatrixBandwidth._requires_structural_symmetry(::GibbsPooleStockmeyer) = true
 allocating `component_orderings` or individual `component[component_ordering]` arrays.
 (Indeed, the only allocations performed here are those performed by `connected_components`,
 individual `_gps_connected_ordering_reversed` calls, and `collect` at the very end.) =#
-function Minimization._bool_minimal_band_ordering(
+function Minimization._minimize_bandwidth_impl(
     A::AbstractMatrix{Bool}, solver::GibbsPooleStockmeyer
 )
     node_finder = solver.node_finder
@@ -270,7 +270,7 @@ end
 #= Gibbs–Poole–Stockmeyer searches each connected component independently. Since the usual
 Gibbs–Poole–Stockmeyer algorithm reverses the ordering, this "reversed" version does not do
 so (i.e., a double reversal, which implies no reversal at all). Instead, the reversal is
-carried out in the `_bool_minimal_band_ordering` method instead. =#
+carried out in the `_minimize_bandwidth_impl` method instead. =#
 function _gps_connected_ordering_reversed(A::AbstractMatrix{Bool}, node_finder::Function)
     u, v = _pseudo_diameter_endpoints(A, node_finder)
     levels_u = _level_structure(A, u)

--- a/src/Minimization/Metaheuristic/Metaheuristic.jl
+++ b/src/Minimization/Metaheuristic/Metaheuristic.jl
@@ -32,7 +32,7 @@ using MatrixBandwidth: NotImplementedError
 using MatrixBandwidth: _requires_structural_symmetry
 
 using MatrixBandwidth.Minimization
-using MatrixBandwidth.Minimization: _approach, _bool_minimal_band_ordering
+using MatrixBandwidth.Minimization: _approach, _minimize_bandwidth_impl
 
 export
     # Types

--- a/src/Minimization/Metaheuristic/solvers/genetic_algorithm.jl
+++ b/src/Minimization/Metaheuristic/solvers/genetic_algorithm.jl
@@ -24,7 +24,7 @@ Base.summary(::GeneticAlgorithm) = "Genetic algorithm"
 
 MatrixBandwidth._requires_structural_symmetry(::GeneticAlgorithm) = false
 
-function Minimization._bool_minimal_band_ordering(
+function Minimization._minimize_bandwidth_impl(
     A::AbstractMatrix{Bool}, solver::GeneticAlgorithm
 )
     error("TODO: Not yet implemented")

--- a/src/Minimization/Metaheuristic/solvers/grasp.jl
+++ b/src/Minimization/Metaheuristic/solvers/grasp.jl
@@ -24,7 +24,7 @@ Base.summary(::GRASP) = "Greedy randomized adaptive search procedure (GRASP)"
 
 MatrixBandwidth._requires_structural_symmetry(::GRASP) = false
 
-function Minimization._bool_minimal_band_ordering(A::AbstractMatrix{Bool}, Solver::GRASP)
+function Minimization._minimize_bandwidth_impl(A::AbstractMatrix{Bool}, Solver::GRASP)
     error("TODO: Not yet implemented")
     return nothing
 end

--- a/src/Minimization/Metaheuristic/solvers/simulated_annealing.jl
+++ b/src/Minimization/Metaheuristic/solvers/simulated_annealing.jl
@@ -30,7 +30,7 @@ Base.summary(::SimulatedAnnealing) = "Simulated annealing"
 
 MatrixBandwidth._requires_structural_symmetry(::SimulatedAnnealing) = false
 
-function Minimization._bool_minimal_band_ordering(
+function Minimization._minimize_bandwidth_impl(
     A::AbstractMatrix{Bool}, solver::SimulatedAnnealing
 )
     error("TODO: Not yet implemented")

--- a/src/Minimization/Minimization.jl
+++ b/src/Minimization/Minimization.jl
@@ -75,9 +75,9 @@ export
     ReverseCuthillMcKee,
 
     # Metaheuristic solvers
+    GRASP,
     SimulatedAnnealing,
-    GeneticAlgorithm,
-    GRASP
+    GeneticAlgorithm
 
 MatrixBandwidth.ALGORITHMS[:Minimization] = Dict{Symbol,Vector}()
 

--- a/src/Minimization/types.jl
+++ b/src/Minimization/types.jl
@@ -23,6 +23,14 @@ Direct subtypes of `AbstractSolver` must implement the following method:
 
 # Supertype Hierarchy
 `AbstractSolver` <: [`AbstractAlgorithm`](@ref)
+
+# Notes
+To implement a new matrix bandwidth minimization algorithm, define a new concrete subtype of
+`AbstractSolver` (or of one of its abstract subtypes like [`MetaheuristicSolver`](@ref))
+then implement a corresponding
+`_minimize_bandwidth_impl(::AbstractMatrix{Bool}, ::NewSolverType)` method. Do *not* attempt
+to directly implement a new [`minimize_bandwidth`](@ref) method, as the function contains
+common preprocessing logic independent of the specific algorithm used.
 """
 abstract type AbstractSolver <: AbstractAlgorithm end
 

--- a/src/Recognition/core.jl
+++ b/src/Recognition/core.jl
@@ -44,13 +44,19 @@ Caprara and Salazar-González (2005). If this lower bound is greater than ``k```
 sections of the [`DelCorsoManzini`](@ref) and [`DelCorsoManziniWithPS`](@ref) docstrings.]
 
 # Notes
-Some texts define matrix bandwidth to be the minimum non-negative integer ``k`` such that
-``A[i, j] = 0`` whenever ``|i - j| ≥ k`` instead, particularly in more mathematically-minded
-communities. Effectively, this definition treats diagonal matrices as bandwidth ``1``,
-tridiagonal matrices as bandwidth ``2``, and so on. Our definition, on the other hand, is
-more common in computer science contexts, treating diagonal matrices as bandwidth ``0`` and
-tridiagonal matrices as bandwidth ``1``. (Both definitions, however, agree that the
-bandwidth of an empty matrix is simply ``0``.)
+To implement a new matrix bandwidth recognition algorithm, define a new concrete subtype of
+[`AbstractDecider`](@ref) then implement a corresponding
+`_has_bandwidth_k_ordering_impl(::AbstractMatrix{Bool}, ::Integer, ::NewDeciderType)`
+method. Do *not* attempt to directly implement a new `has_bandwidth_k_ordering` method, as
+the function contains common preprocessing logic independent of the specific algorithm used.
+
+Note also that some texts define matrix bandwidth to be the minimum non-negative integer
+``k`` such that ``A[i, j] = 0`` whenever ``|i - j| ≥ k`` instead, particularly in more
+mathematically-minded communities. Effectively, this definition treats diagonal matrices as
+bandwidth ``1``, tridiagonal matrices as bandwidth ``2``, and so on. Our definition, on the
+other hand, is more common in computer science contexts, treating diagonal matrices as
+bandwidth ``0`` and tridiagonal matrices as bandwidth ``1``. (Both definitions, however,
+agree that the bandwidth of an empty matrix is simply ``0``.)
 """
 function has_bandwidth_k_ordering(
     A::AbstractMatrix{<:Number}, k::Integer, decider::AbstractDecider=DEFAULT_DECIDER
@@ -74,7 +80,7 @@ function has_bandwidth_k_ordering(
         values. We also set every diagonal entry to `false` for consistency with any algorithms
         that assume an adjacency matrix structure. =#
         A_bool = offdiag_nz_support(A)
-        ordering = _bool_bandwidth_k_ordering(A_bool, k, decider)
+        ordering = _has_bandwidth_k_ordering_impl(A_bool, k, decider)
     else
         ordering = nothing
     end
@@ -85,10 +91,10 @@ end
 #= Compute an ordering inducing a bandwidth of at most `k` for a preprocessed
 `AbstractMatrix{Bool}`, if one exists; otherwise, return `nothing`. Restricting entries to
 booleans can improve performance via cache optimizations, bitwise operations, etc. Each
-concrete subtype of `AbstractDecider` must implement its own `_bool_bandwidth_k_ordering`
-method to define the corresponding algorithm logic. =#
-function _bool_bandwidth_k_ordering(
+concrete subtype of `AbstractDecider` must implement its own
+`_has_bandwidth_k_ordering_impl` method to define the corresponding algorithm logic. =#
+function _has_bandwidth_k_ordering_impl(
     ::AbstractMatrix{Bool}, ::Integer, ::T
 ) where {T<:AbstractDecider}
-    throw(NotImplementedError(_bool_bandwidth_k_ordering, :decider, T, AbstractDecider))
+    throw(NotImplementedError(_has_bandwidth_k_ordering_impl, :decider, T, AbstractDecider))
 end

--- a/src/Recognition/deciders/brute_force_search.jl
+++ b/src/Recognition/deciders/brute_force_search.jl
@@ -92,7 +92,9 @@ MatrixBandwidth._requires_structural_symmetry(::BruteForceSearch) = false
 
 #= We take advantage of the laziness of `permutations` and `Iterators.filter` to avoid
 iterating over all orderings if a valid one is found early. =#
-function _bool_bandwidth_k_ordering(A::AbstractMatrix{Bool}, k::Integer, ::BruteForceSearch)
+function _has_bandwidth_k_ordering_impl(
+    A::AbstractMatrix{Bool}, k::Integer, ::BruteForceSearch
+)
     #= `i₁, i₂, … iₙ` induces the same bandwidth as `iₙ, iₙ₋₁, … i₁`, so without loss of
     generality, we restrict our search to orderings such that `i₁ ≤ iₙ` (with equality
     checked just in case `n = 1`). =#

--- a/src/Recognition/deciders/caprara_salazar_gonzalez.jl
+++ b/src/Recognition/deciders/caprara_salazar_gonzalez.jl
@@ -52,7 +52,7 @@ Base.summary(::CapraraSalazarGonzalez) = "Caprara–Salazar-González"
 
 MatrixBandwidth._requires_structural_symmetry(::CapraraSalazarGonzalez) = true
 
-function _bool_bandwidth_k_ordering(
+function _has_bandwidth_k_ordering_impl(
     A::AbstractMatrix{Bool}, k::Integer, ::CapraraSalazarGonzalez
 )
     error("TODO: Not yet implemented")

--- a/src/Recognition/deciders/del_corso_manzini.jl
+++ b/src/Recognition/deciders/del_corso_manzini.jl
@@ -229,8 +229,8 @@ struct DelCorsoManziniWithPS{D<:Union{Nothing,Integer}} <: AbstractDecider
 
     #= We cannot compute a (hopefully) near-optimal perimeter search depth upon
     instantiation of the decider, as it depends on the input matrix as well. Hence, we use
-    `nothing` as a sentinel to indicate to `_bool_bandwidth_k_ordering` that a default depth
-    still needs to be computed upon the function call. =#
+    `nothing` as a sentinel to indicate to `_has_bandwidth_k_ordering_impl` that a default
+    depth still needs to be computed upon the function call. =#
     DelCorsoManziniWithPS() = new{Nothing}(nothing)
 
     function DelCorsoManziniWithPS(depth::Integer)
@@ -306,7 +306,9 @@ function dcm_ps_optimal_depth(A::AbstractMatrix{Bool})
     return round(Int, optimal_depth)
 end
 
-function _bool_bandwidth_k_ordering(A::AbstractMatrix{Bool}, k::Integer, ::DelCorsoManzini)
+function _has_bandwidth_k_ordering_impl(
+    A::AbstractMatrix{Bool}, k::Integer, ::DelCorsoManzini
+)
     n = size(A, 1)
 
     ordering_buf = Vector{Int}(undef, n)
@@ -325,16 +327,16 @@ function _bool_bandwidth_k_ordering(A::AbstractMatrix{Bool}, k::Integer, ::DelCo
     )
 end
 
-function _bool_bandwidth_k_ordering(
+function _has_bandwidth_k_ordering_impl(
     A::AbstractMatrix{Bool}, k::Integer, ::DelCorsoManziniWithPS{Nothing}
 )
     #= We cannot compute a (hopefully) near-optimal perimeter search depth upon
     instantiation of the decider, as it depends on the input matrix as well. =#
     decider_with_depth = DelCorsoManziniWithPS(dcm_ps_optimal_depth(A))
-    return _bool_bandwidth_k_ordering(A, k, decider_with_depth)
+    return _has_bandwidth_k_ordering_impl(A, k, decider_with_depth)
 end
 
-function _bool_bandwidth_k_ordering(
+function _has_bandwidth_k_ordering_impl(
     A::AbstractMatrix{Bool}, k::Integer, decider::DelCorsoManziniWithPS{Integer}
 )
     n = size(A, 1)

--- a/src/Recognition/deciders/saxe_gurari_sudborough.jl
+++ b/src/Recognition/deciders/saxe_gurari_sudborough.jl
@@ -103,7 +103,7 @@ Base.summary(::SaxeGurariSudborough) = "Saxe–Gurari–Sudborough"
 
 MatrixBandwidth._requires_structural_symmetry(::SaxeGurariSudborough) = true
 
-function _bool_bandwidth_k_ordering(
+function _has_bandwidth_k_ordering_impl(
     A::AbstractMatrix{Bool}, k::Integer, ::SaxeGurariSudborough
 )
     components = connected_components(A)

--- a/src/Recognition/types.jl
+++ b/src/Recognition/types.jl
@@ -19,6 +19,14 @@ As per the interface of supertype [`AbstractAlgorithm`](@ref), concrete subtypes
 
 # Supertype Hierarchy
 `AbstractDecider` <: [`AbstractAlgorithm`](@ref)
+
+# Notes
+To implement a new matrix bandwidth recognition algorithm, define a new concrete subtype of
+`AbstractDecider` then implement a corresponding
+`_has_bandwidth_k_ordering_impl(::AbstractMatrix{Bool}, ::Integer, ::NewDeciderType)`
+method. Do *not* attempt to directly implement a new [`has_bandwidth_k_ordering`](@ref)
+method, as the function contains common preprocessing logic independent of the specific
+algorithm used.
 """
 abstract type AbstractDecider <: AbstractAlgorithm end
 


### PR DESCRIPTION
This PR renames '_bool_minimal_band_ordering' and '_bool_bandwidth_k_ordering' (the functions wherein new algorithm logic is defined) to '_minimize_bandwidth_impl' and '_has_bandwidth_k_ordering_impl', respectively. It also adds instructions to the documentation for extending the interface with new algorithms via these methods.