### PR TITLE
Reduce CSG tests for runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Added doctest examples for the `minimize_bandwidth` and `has_bandwidth_k_ordering` functions (#154).
-- Implemented the Caprara&ndash;Salazar-Gonz&aacute;lez algorithm (both the minimization solver and the recognition decider), concurrently adding *JuMP.jl* and *HiGHS.jl* as notable dependencies for integer linear programming (#137, #149, #152).
+- Implemented the Caprara&ndash;Salazar-Gonz&aacute;lez algorithm (both the minimization solver and the recognition decider), concurrently adding *JuMP.jl* and *HiGHS.jl* as notable dependencies for integer linear programming (#137, #149, #152, #156).
 
 ### Changed
 

--- a/test/Recognition/deciders/caprara_salazar_gonzalez.jl
+++ b/test/Recognition/deciders/caprara_salazar_gonzalez.jl
@@ -16,12 +16,11 @@ using MatrixBandwidth.Recognition
 using SparseArrays
 using Test
 
-const MAX_ORDER_LE = 7
-const MAX_ORDER_GT = 8
+const MAX_ORDER = 7
 const NUM_ITER = 10
 
-@testset "CSG decider – Bandwidth ≤ k (n ≤ $MAX_ORDER_LE)" begin
-    for n in 1:MAX_ORDER_LE, _ in 1:NUM_ITER
+@testset "CSG decider – Bandwidth ≤ k (n ≤ $MAX_ORDER)" begin
+    for n in 1:MAX_ORDER, _ in 1:NUM_ITER
         density = rand()
         A = sprand(n, n, density)
         A = A + A' # Ensure structural symmetry
@@ -37,8 +36,8 @@ const NUM_ITER = 10
     end
 end
 
-@testset "CSG decider – Bandwidth > k (n ≤ $MAX_ORDER_GT)" begin
-    for n in 2:MAX_ORDER_GT, i in 1:NUM_ITER
+@testset "CSG decider – Bandwidth > k (n ≤ $MAX_ORDER)" begin
+    for n in 2:MAX_ORDER, i in 1:NUM_ITER
         density = rand()
         A = sprand(n, n, density)
         A = A + A' # Ensure structural symmetry


### PR DESCRIPTION
Reduce the maximum order for all Caprara-Salazar-Gonzalez tests from 8 to 7 to avoid long runtimes.