### PR TITLE
Add Julia 1.12 to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,7 @@ jobs:
         version:
           - '1.10'
           - '1.11'
+          - '1.12'
           - 'pre'
         os:
           - ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Updated the GitHub Actions CI workflow to include Julia 1.12 in the testing matrix (#179).
+- Added a unit test in `test/readme_example.jl` to ensure that the example code blocks in `README.md` and `docs/src/index.md` (which corresponds to the homepage of the Documenter.jl-generated documentation) align with the actual output of the package on 64-bit architectures (#178).
 - Added a *Journal of Open Source Software* (JOSS) badge to `README.md` and `docs/src/index.md` indicating that the package is currently under review by JOSS (#174).
 
 ### Changed
 
-- Added a unit test in `test/readme_example.jl` to ensure that the example code blocks in `README.md` and `docs/src/index.md` (which corresponds to the homepage of the Documenter.jl-generated documentation) align with the actual output of the package on 64-bit architectures (#178).
 - Made examples in the docstrings runnable (thus avoiding hardcoding output) by switching from `jldoctest` to `@repl` (#176).
 
 ## [0.2.1] - 2025-09-24


### PR DESCRIPTION
This commit updates the GitHub Actions CI workflow to include Julia 1.12 in the testing matrix.

We also move the `CHANGELOG.md` entry for PR #178 from the "Changed" section to the "Added" section - its initial placement in the "Changed" section was just a careless oversight.