### PR TITLE
Link to docs on main names in 'README.md'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added clear links to the documentation on `minimize_bandwidth`, `has_bandwidth_k_ordering`, and their respective output structs in `README.md` and `docs/src/index.md` (#180).
 - Updated the GitHub Actions CI workflow to include Julia 1.12 in the testing matrix (#179).
 - Added a unit test in `test/readme_example.jl` to ensure that the example code blocks in `README.md` and `docs/src/index.md` (which corresponds to the homepage of the Documenter.jl-generated documentation) align with the actual output of the package on 64-bit architectures (#178).
 - Added a *Journal of Open Source Software* (JOSS) badge to `README.md` and `docs/src/index.md` indicating that the package is currently under review by JOSS (#174).

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ pkg> add MatrixBandwidth
 
 ## Basic use
 
-MatrixBandwidth.jl offers unified interfaces for both bandwidth minimization and bandwidth recognition via the `minimize_bandwidth` and `has_bandwidth_k_ordering` functions, respectively&mdash;the algorithm itself is specified as an argument. For example, to minimize the bandwidth of a random matrix with the reverse Cuthill&ndash;McKee algorithm, you can run the following code:
+MatrixBandwidth.jl offers unified interfaces for both bandwidth minimization and bandwidth recognition via the `minimize_bandwidth` and `has_bandwidth_k_ordering` functions, respectively&mdash;the algorithm itself is specified as an argument. Comprehensive documentation for these two methods is available [here](https://luis-varona.github.io/MatrixBandwidth.jl/stable/public_api/#MatrixBandwidth.Minimization.minimize_bandwidth) and [here](https://luis-varona.github.io/MatrixBandwidth.jl/stable/public_api/#MatrixBandwidth.Recognition.has_bandwidth_k_ordering), and further details about their respective output structs can be found [here](http://luis-varona.github.io/MatrixBandwidth.jl/stable/public_api/#MatrixBandwidth.Minimization.MinimizationResult) and [here](https://luis-varona.github.io/MatrixBandwidth.jl/stable/public_api/#MatrixBandwidth.Recognition.RecognitionResult). We go over some basic examples below.
+
+To minimize the bandwidth of a random matrix with, say, the reverse Cuthill&ndash;McKee algorithm, you can run the following code:
 
 ```julia-repl
 julia> using Random, SparseArrays

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -108,7 +108,9 @@ pkg> add MatrixBandwidth
 
 ## Basic use
 
-MatrixBandwidth.jl offers unified interfaces for both bandwidth minimization and bandwidth recognition via the `minimize_bandwidth` and `has_bandwidth_k_ordering` functions, respectively—the algorithm itself is specified as an argument. For example, to minimize the bandwidth of a random matrix with the reverse Cuthill–McKee algorithm, you can run the following code:
+MatrixBandwidth.jl offers unified interfaces for both bandwidth minimization and bandwidth recognition via the `minimize_bandwidth` and `has_bandwidth_k_ordering` functions, respectively—the algorithm itself is specified as an argument. Comprehensive documentation for these two methods is available [here](https://luis-varona.github.io/MatrixBandwidth.jl/stable/public_api/#MatrixBandwidth.Minimization.minimize_bandwidth) and [here](https://luis-varona.github.io/MatrixBandwidth.jl/stable/public_api/#MatrixBandwidth.Recognition.has_bandwidth_k_ordering), and further details about their respective output structs can be found [here](http://luis-varona.github.io/MatrixBandwidth.jl/stable/public_api/#MatrixBandwidth.Minimization.MinimizationResult) and [here](https://luis-varona.github.io/MatrixBandwidth.jl/stable/public_api/#MatrixBandwidth.Recognition.RecognitionResult). We go over some basic examples below.
+
+To minimize the bandwidth of a random matrix with, say, the reverse Cuthill&ndash;McKee algorithm, you can run the following code:
 
 ```julia-repl
 julia> using Random, SparseArrays


### PR DESCRIPTION
This commit adds clear links to the documentation on 'minimize_bandwidth', 'has_bandwidth_k_ordering', and their respective output structs in 'README.md' and 'docs/src/index.md'.

(This should address point 4 raised by @tmigot in issue #173.)