### PR TITLE
Fix indexing conflict in Documenter website

### DIFF
--- a/docs/src/private_api.md
+++ b/docs/src/private_api.md
@@ -9,42 +9,42 @@ Documentation for [MatrixBandwidth](https://github.com/Luis-Varona/MatrixBandwid
 !!! note
     The following documentation covers only the private API of the package. For public details, see the [public API documentation](public_api.md).
 
-## `MatrixBandwidth`
+## `MatrixBandwidth` (Private)
 
 ```@autodocs
 Modules = [MatrixBandwidth]
 Public = false
 ```
 
-## `MatrixBandwidth.Minimization`
+## `MatrixBandwidth.Minimization` (Private)
 
 ```@autodocs
 Modules = [MatrixBandwidth.Minimization]
 Public = false
 ```
 
-## `MatrixBandwidth.Minimization.Exact`
+## `MatrixBandwidth.Minimization.Exact` (Private)
 
 ```@autodocs
 Modules = [MatrixBandwidth.Minimization.Exact]
 Public = false
 ```
 
-## `MatrixBandwidth.Minimization.Heuristic`
+## `MatrixBandwidth.Minimization.Heuristic` (Private)
 
 ```@autodocs
 Modules = [MatrixBandwidth.Minimization.Heuristic]
 Public = false
 ```
 
-## `MatrixBandwidth.Minimization.Metaheuristic`
+## `MatrixBandwidth.Minimization.Metaheuristic` (Private)
 
 ```@autodocs
 Modules = [MatrixBandwidth.Minimization.Metaheuristic]
 Public = false
 ```
 
-## `MatrixBandwidth.Recognition`
+## `MatrixBandwidth.Recognition` (Private)
 
 ```@autodocs
 Modules = [MatrixBandwidth.Recognition]

--- a/docs/src/public_api.md
+++ b/docs/src/public_api.md
@@ -9,42 +9,42 @@ Documentation for [MatrixBandwidth](https://github.com/Luis-Varona/MatrixBandwid
 !!! note
     The following documentation covers only the public API of the package. For internal details, see the [private API documentation](private_api.md).
 
-## `MatrixBandwidth`
+## `MatrixBandwidth` (Public)
 
 ```@autodocs
 Modules = [MatrixBandwidth]
 Private = false
 ```
 
-## `MatrixBandwidth.Minimization`
+## `MatrixBandwidth.Minimization` (Public)
 
 ```@autodocs
 Modules = [MatrixBandwidth.Minimization]
 Private = false
 ```
 
-## `MatrixBandwidth.Minimization.Exact`
+## `MatrixBandwidth.Minimization.Exact` (Public)
 
 ```@autodocs
 Modules = [MatrixBandwidth.Minimization.Exact]
 Private = false
 ```
 
-## `MatrixBandwidth.Minimization.Heuristic`
+## `MatrixBandwidth.Minimization.Heuristic` (Public)
 
 ```@autodocs
 Modules = [MatrixBandwidth.Minimization.Heuristic]
 Private = false
 ```
 
-## `MatrixBandwidth.Minimization.Metaheuristic`
+## `MatrixBandwidth.Minimization.Metaheuristic` (Public)
 
 ```@autodocs
 Modules = [MatrixBandwidth.Minimization.Metaheuristic]
 Private = false
 ```
 
-## `MatrixBandwidth.Recognition`
+## `MatrixBandwidth.Recognition` (Public)
 
 ```@autodocs
 Modules = [MatrixBandwidth.Recognition]


### PR DESCRIPTION
The bump from Documenter v1.15.0 to v1.16.0 resulted in errors building the documentation due to conflicting headers between the private and public API sections. This fixes that bug.