### PR TITLE
Eliminate unnecessary 'u != v' check in SGS algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Eliminated an unnecessary `u != v` check when filtering adjacent nodes in the Saxe–Gurari–Sudborough recognition decider's `_sgs_dangling_new` function, since the core `has_bandwidth_k_ordering` function that dispatches to the decider already ensures that no self-loops exist in the input graph (#204).
 - Replaced `processed` and `visited` sets in the Saxe–Gurari–Sudborough recognition decider with boolean arrays to improve performance (#203).
 - Updated `CONTRIBUTING.md` with a paragraph about adding to the changelog, as well as a minor typo fix (#202).
 - Raised the threshold for number of JET reports in static analysis testing from 20 to 30 (#201).

--- a/src/Recognition/deciders/saxe_gurari_sudborough.jl
+++ b/src/Recognition/deciders/saxe_gurari_sudborough.jl
@@ -273,7 +273,7 @@ function _sgs_dangling_new(
         dangling, Iterators.map(u -> _pot_edge(u, v), neighbors_in_region)
     )
     additional_edges = Iterators.map(
-        u -> _pot_edge(u, v), Iterators.filter(u -> u != v && !(u in region), adj_list)
+        u -> _pot_edge(u, v), Iterators.filter(!in(region), adj_list)
     )
     return union!(dangling_new, additional_edges)
 end


### PR DESCRIPTION
We eliminate an unnecessary check for self-loops in the SGS recognition decider's '_sgs_dangling_new' function, since the core 'has_bandwidth_k_ordering' function that dispatches to the decider already ensures that no self-loops exist in the input graph.