### PR TITLE
Some minor micro-optimizations for SGS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- Eliminated an unnecessary `u != v` check when filtering adjacent nodes in the Saxe–Gurari–Sudborough recognition decider's `_sgs_dangling_new` function, since the core `has_bandwidth_k_ordering` function that dispatches to the decider already ensures that no self-loops exist in the input graph (#204).
+- Made a few micro-optimizations to the Saxe–Gurari–Sudborough recognition decider (e.g., avoiding unnecessary duplicate checks/moving computations to later in the control flow when appropriate) (#204, #205).
 - Replaced `processed` and `visited` sets in the Saxe–Gurari–Sudborough recognition decider with boolean arrays to improve performance (#203).
 - Updated `CONTRIBUTING.md` with a paragraph about adding to the changelog, as well as a minor typo fix (#202).
 - Raised the threshold for number of JET reports in static analysis testing from 20 to 30 (#201).

--- a/src/Recognition/deciders/saxe_gurari_sudborough.jl
+++ b/src/Recognition/deciders/saxe_gurari_sudborough.jl
@@ -180,9 +180,8 @@ function _sgs_connected_ordering(A::AbstractMatrix{Bool}, k::Integer)
             region_new = _sgs_region_new(region_extended, dangling_new, k)
 
             if !isnothing(region_new)
-                key_new = _sgs_key(region_new, dangling_new)
-
                 if _sgs_layout_is_plausible(region_new, dangling_new, k)
+                    key_new = _sgs_key(region_new, dangling_new)
                     num_placed_new = num_placed + 1
 
                     if num_placed_new == n
@@ -283,10 +282,7 @@ function _sgs_region_new(
     region_extended::Vector{Int}, dangling_new::Set{Tuple{Int,Int}}, k::Integer
 )
     first_idx_in_region = Dict{Int,Int}()
-    foreach(
-        ((i, v),) -> first_idx_in_region[v] = get(first_idx_in_region, v, i),
-        enumerate(region_extended),
-    )
+    foreach(((i, v),) -> first_idx_in_region[v] = i, enumerate(region_extended))
     region_extended_set = Set(region_extended)
     active_new = Set(
         Iterators.filter(in(region_extended_set), Iterators.flatten(dangling_new))


### PR DESCRIPTION
We avoid some unnecessary duplicate checks, move computations to later in the control flow, etc. in the Saxe-Gurari-Sudborough recognition decider logic.