### PR TITLE
Fix minor bug in DCM algorithm(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Fixed off-by-one bug in the expiration-time pruning of the Del Corso–Manzini algorithm(s) (did not affect correctness, only performance) (#211).
 - Fixed several discrepancies between the Gibbs–Poole–Stockmeyer minimization algorithm as described in the original paper and its implementation (the `README` and tutorial examples was also updated accordingly) (#209).
 
 ## [0.2.3] - 2025-12-29

--- a/src/Recognition/deciders/del_corso_manzini.jl
+++ b/src/Recognition/deciders/del_corso_manzini.jl
@@ -436,7 +436,7 @@ function _dcm_order_is_reversed(
         max_last_label = maximum(unselected)
     end
 
-    return max_last_label <= first_label
+    return max_last_label < first_label
 end
 
 function _dcm_lpo_time_stamps(lpo::Vector{Int}, A::AbstractMatrix{Bool}, k::Integer)
@@ -524,7 +524,7 @@ function _dcm_is_compatible(
         compat = false
     else
         placed_nodes = view(ordering_buf, 1:num_placed)
-        constraints = (1:l) .+ num_placed
+        constraints = (1:l) .+ (num_placed + 1)
 
         latest_positions = Iterators.map(
             neighbor -> findfirst(node -> A[node, neighbor], placed_nodes), adj_list


### PR DESCRIPTION
We fix an off-by-one bug in the expiration-time pruning of the Del Corso--Manzini algorithms (did not affect correctness, only performance).

(Additionally, we change `return max_last_label <= first_label` to `return max_last_label <= first_label` on line 439; this doesn't affect correctness, since in the n = 1 case this lower-level implementation is all skipped anyway, but it matches the intent better semantically.)