### PR TITLE
Remove nightly CI runs from Github Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,6 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
-    continue-on-error: ${{ matrix.version == 'pre' }}
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
       actions: write
       contents: read
@@ -27,7 +26,6 @@ jobs:
           - '1.10'
           - '1.11'
           - '1.12'
-          - 'pre'
         os:
           - ubuntu-latest
         arch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-### Changed
+### Removed
 
-- Updated the GitHub Actions CI workflow to allow nightly CI runs (on `pre`) to fail without affecting the overall status of the workflow (#210).
+- Removed nightly CI runs (on `pre`) from the GitHub Actions CI workflow, since they often fail due to incompatibilities with dependencies in the testing matrix (#212).
 
 ### Fixed
 


### PR DESCRIPTION
We remove nightly CI runs (on 'pre') from the GitHub Actions CI workflow, since they often fail due to incompatibilities with dependencies in the testing matrix.