### PR TITLE
Reduce allocations in '_blb_connected'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-### Removed
+### Changed
 
-- Removed nightly CI runs (on `pre`) from the GitHub Actions CI workflow, since they often fail due to incompatibilities with dependencies in the testing matrix (#212).
+- Updated the `_blb_connected` helper (used in `bandwidth_lower_bound`) to avoid unnecessary allocations, now requiring only `O(n)` auxiliary space instead of `O(n^2)` (#213).
 
 ### Fixed
 
 - Fixed off-by-one bug in the expiration-time pruning of the Del Corso–Manzini algorithm(s) (did not affect correctness, only performance) (#211).
 - Fixed several discrepancies between the Gibbs–Poole–Stockmeyer minimization algorithm as described in the original paper and its implementation (the `README` and tutorial examples was also updated accordingly) (#209).
+
+### Removed
+
+- Removed nightly CI runs (on `pre`) from the GitHub Actions CI workflow, since they often fail due to incompatibilities with dependencies in the testing matrix (#212).
 
 ## [0.2.3] - 2025-12-29
 


### PR DESCRIPTION
We reduce the auxiliary space requirement of the '_blb_connected' helper (used in 'bandwidth_lower_bound') from O(n^2) to O(n) while keeping the same O(n^3) time complexity. In particular, we perform breadth-first searches without storing the entire distance matrix, instead storing distances from one source at a time and reusing preallocated buffers.

(Additionally, we dispense with the preliminary check of whether the input is a full matrix, since this is a very rare case and will still result in a lower bound of n - 1 in the end anyway.)